### PR TITLE
Firebreak: Add new APIs for validating signatures

### DIFF
--- a/saml-metadata-bindings-test/src/main/java/uk/gov/ida/saml/metadata/test/factories/metadata/TestCredentialFactory.java
+++ b/saml-metadata-bindings-test/src/main/java/uk/gov/ida/saml/metadata/test/factories/metadata/TestCredentialFactory.java
@@ -64,7 +64,7 @@ public class TestCredentialFactory {
         return publicKey;
     }
 
-    private PublicKey createPublicKey(String partialCert) throws CertificateException, UnsupportedEncodingException {
+    public static PublicKey createPublicKey(String partialCert) throws CertificateException, UnsupportedEncodingException {
         CertificateFactory certificateFactory;
         certificateFactory = CertificateFactory.getInstance("X.509");
         String fullCert;

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheck.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheck.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class EidasTrustAnchorHealthCheck extends HealthCheck {
 
@@ -40,7 +41,7 @@ public class EidasTrustAnchorHealthCheck extends HealthCheck {
     }
 
     private List<String> getErrorsCreatingMetadataResolvers(List<String> trustAnchorEntityIds) {
-        HashMap<String, MetadataResolver> metadataResolvers = metadataResolverRepository.getMetadataResolvers();
+        Map<String, MetadataResolver> metadataResolvers = metadataResolverRepository.getMetadataResolvers();
 
         if (trustAnchorEntityIds.size() > metadataResolvers.keySet().size()) {
             List<String> missingMetadataResolverEntityIds = new ArrayList<>(trustAnchorEntityIds);
@@ -52,7 +53,7 @@ public class EidasTrustAnchorHealthCheck extends HealthCheck {
     }
 
     private List<String> getErrorsResolvingMetadata() {
-        HashMap<String, MetadataResolver> metadataResolvers = metadataResolverRepository.getMetadataResolvers();
+        Map<String, MetadataResolver> metadataResolvers = metadataResolverRepository.getMetadataResolvers();
         List<String> errors = new ArrayList<>();
         for (String entityId : metadataResolvers.keySet()) {
             try {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
@@ -6,9 +6,12 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.security.credential.CredentialResolver;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
+import uk.gov.ida.saml.metadata.factories.CredentialResolverFactory;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 
@@ -19,6 +22,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
     private MetadataResolver metadataResolver;
     private DropwizardMetadataResolverFactory dropwizardMetadataResolverFactory = new DropwizardMetadataResolverFactory();
     private ExplicitKeySignatureTrustEngine signatureTrustEngine;
+    private MetadataCredentialResolver credentialResolver;
 
     public MetadataResolverBundle(MetadataConfigurationExtractor<T> configExtractor) {
         this.configExtractor = configExtractor;
@@ -29,6 +33,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
         MetadataResolverConfiguration metadataConfiguration = configExtractor.getMetadataConfiguration(configuration);
         metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, metadataConfiguration);
         signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(metadataResolver);
+        credentialResolver = new CredentialResolverFactory().create(metadataResolver);
     }
 
     @Override
@@ -51,6 +56,15 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
 
     public Provider<ExplicitKeySignatureTrustEngine> getSignatureTrustEngineProvider() {
         return () -> signatureTrustEngine;
+    }
+
+    @Nullable
+    public MetadataCredentialResolver getMetadataCredentialResolver() {
+        return credentialResolver;
+    }
+
+    public Provider<MetadataCredentialResolver> getMetadataCredentialResolverProvider() {
+        return () -> credentialResolver;
     }
 
     public Module getMetadataModule() {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
@@ -4,9 +4,13 @@ import com.google.inject.Module;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 
 import javax.inject.Provider;
 
@@ -14,6 +18,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
     private MetadataConfigurationExtractor<T> configExtractor;
     private MetadataResolver metadataResolver;
     private DropwizardMetadataResolverFactory dropwizardMetadataResolverFactory = new DropwizardMetadataResolverFactory();
+    private ExplicitKeySignatureTrustEngine signatureTrustEngine;
 
     public MetadataResolverBundle(MetadataConfigurationExtractor<T> configExtractor) {
         this.configExtractor = configExtractor;
@@ -23,6 +28,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
     public void run(T configuration, Environment environment) throws Exception {
         MetadataResolverConfiguration metadataConfiguration = configExtractor.getMetadataConfiguration(configuration);
         metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, metadataConfiguration);
+        signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(metadataResolver);
     }
 
     @Override
@@ -36,6 +42,15 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
 
     public Provider<MetadataResolver> getMetadataResolverProvider() {
         return () -> metadataResolver;
+    }
+
+    @Nullable
+    public ExplicitKeySignatureTrustEngine getSignatureTrustEngine() {
+        return signatureTrustEngine;
+    }
+
+    public Provider<ExplicitKeySignatureTrustEngine> getSignatureTrustEngineProvider() {
+        return () -> signatureTrustEngine;
     }
 
     public Module getMetadataModule() {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundle.java
@@ -15,23 +15,30 @@ import uk.gov.ida.saml.metadata.factories.CredentialResolverFactory;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Provider;
 
 public class MetadataResolverBundle<T extends Configuration> implements io.dropwizard.ConfiguredBundle<T> {
-    private MetadataConfigurationExtractor<T> configExtractor;
+    private final MetadataConfigurationExtractor<T> configExtractor;
     private MetadataResolver metadataResolver;
     private DropwizardMetadataResolverFactory dropwizardMetadataResolverFactory = new DropwizardMetadataResolverFactory();
     private ExplicitKeySignatureTrustEngine signatureTrustEngine;
     private MetadataCredentialResolver credentialResolver;
+    private final boolean validateSignatures;
 
     public MetadataResolverBundle(MetadataConfigurationExtractor<T> configExtractor) {
+        this(configExtractor, true);
+    }
+
+    public MetadataResolverBundle(MetadataConfigurationExtractor<T> configExtractor, boolean validateSignatures) {
         this.configExtractor = configExtractor;
+        this.validateSignatures = validateSignatures;
     }
 
     @Override
     public void run(T configuration, Environment environment) throws Exception {
         MetadataResolverConfiguration metadataConfiguration = configExtractor.getMetadataConfiguration(configuration);
-        metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, metadataConfiguration);
+        metadataResolver = dropwizardMetadataResolverFactory.createMetadataResolver(environment, metadataConfiguration, validateSignatures);
         signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(metadataResolver);
         credentialResolver = new CredentialResolverFactory().create(metadataResolver);
     }
@@ -66,6 +73,7 @@ public class MetadataResolverBundle<T extends Configuration> implements io.dropw
     public Provider<MetadataCredentialResolver> getMetadataCredentialResolverProvider() {
         return () -> credentialResolver;
     }
+
 
     public Module getMetadataModule() {
       return binder -> binder.bind(MetadataResolver.class).toProvider(getMetadataResolverProvider());

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactory.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.metadata.factories;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+
+public class CredentialResolverFactory {
+    public MetadataCredentialResolver create(MetadataResolver metadataResolver) throws ComponentInitializationException {
+        PredicateRoleDescriptorResolver roleDescriptorResolver = new PredicateRoleDescriptorResolver(metadataResolver);
+        roleDescriptorResolver.initialize();
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolver();
+        metadataCredentialResolver.setRoleDescriptorResolver(roleDescriptorResolver);
+        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+        metadataCredentialResolver.initialize();
+        return metadataCredentialResolver;
+    }
+}

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/DropwizardMetadataResolverFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/DropwizardMetadataResolverFactory.java
@@ -28,7 +28,7 @@ public class DropwizardMetadataResolverFactory {
         return createMetadataResolver(environment, metadataConfiguration, false);
     }
 
-    private MetadataResolver createMetadataResolver(Environment environment, MetadataResolverConfiguration metadataConfiguration, boolean validateSignatures) {
+    public MetadataResolver createMetadataResolver(Environment environment, MetadataResolverConfiguration metadataConfiguration, boolean validateSignatures) {
         URI uri = metadataConfiguration.getUri();
         Long minRefreshDelay = metadataConfiguration.getMinRefreshDelay();
         Long maxRefreshDelay = metadataConfiguration.getMaxRefreshDelay();

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactory.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.saml.metadata.factories;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+
+public class MetadataSignatureTrustEngineFactory {
+    public ExplicitKeySignatureTrustEngine createSignatureTrustEngine(MetadataResolver metadataResolver) throws ComponentInitializationException {
+        PredicateRoleDescriptorResolver roleDescriptorResolver = new PredicateRoleDescriptorResolver(metadataResolver);
+        roleDescriptorResolver.initialize();
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolver();
+        metadataCredentialResolver.setRoleDescriptorResolver(roleDescriptorResolver);
+        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+        metadataCredentialResolver.initialize();
+        return new ExplicitKeySignatureTrustEngine(
+                metadataCredentialResolver, DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver()
+        );
+    }
+}

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
@@ -1,14 +1,26 @@
 package uk.gov.ida.saml.metadata;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.codahale.metrics.MetricRegistry;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import io.dropwizard.setup.Environment;
+import net.minidev.json.JSONObject;
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 
-import java.net.URISyntaxException;
 import java.security.KeyStoreException;
 import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
@@ -22,23 +34,13 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import com.codahale.metrics.MetricRegistry;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.JWK;
-import io.dropwizard.setup.Environment;
-import net.minidev.json.JSONObject;
-import org.apache.commons.codec.binary.Base64;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import uk.gov.ida.common.shared.security.X509CertificateFactory;
-import uk.gov.ida.saml.core.test.TestCertificateStrings;
-import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EidasMetadataResolverRepositoryTest {
@@ -61,6 +63,12 @@ public class EidasMetadataResolverRepositoryTest {
     @Mock
     private MetadataResolver metadataResolver;
 
+    @Mock
+    private MetadataSignatureTrustEngineFactory metadataSignatureTrustEngineFactory;
+
+    @Mock
+    private ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine;
+
     @Captor
     ArgumentCaptor<MetadataResolverConfiguration> metadataResolverConfigurationCaptor;
 
@@ -69,10 +77,11 @@ public class EidasMetadataResolverRepositoryTest {
     private List<JWK> trustAnchors;
 
     @Before
-    public void setUp() throws CertificateException, SignatureException, ParseException, JOSEException, URISyntaxException {
+    public void setUp() throws CertificateException, SignatureException, ParseException, JOSEException, ComponentInitializationException {
         trustAnchors = new ArrayList<>();
         when(trustAnchorResolver.getTrustAnchors()).thenReturn(trustAnchors);
         when(dropwizardMetadataResolverFactory.createMetadataResolver(eq(environment), any())).thenReturn(metadataResolver);
+        when(metadataSignatureTrustEngineFactory.createSignatureTrustEngine(metadataResolver)).thenReturn(explicitKeySignatureTrustEngine);
     }
 
     @Test
@@ -80,10 +89,10 @@ public class EidasMetadataResolverRepositoryTest {
         JWK trustAnchor = createJWK("http://signin.gov.uk/entity/id", Arrays.asList(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT,
                 TestCertificateStrings.METADATA_SIGNING_B_PUBLIC_CERT));
         trustAnchors.add(trustAnchor);
-        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer);
+        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer, metadataSignatureTrustEngineFactory);
 
-        MetadataResolver createdMetadataResolver = metadataResolverRepository.getMetadataResolver(trustAnchor.getKeyID());
         verify(dropwizardMetadataResolverFactory).createMetadataResolver(eq(environment), metadataResolverConfigurationCaptor.capture());
+        MetadataResolver createdMetadataResolver = metadataResolverRepository.getMetadataResolver(trustAnchor.getKeyID());
         MetadataResolverConfiguration metadataResolverConfiguration = metadataResolverConfigurationCaptor.getValue();
         byte[] expectedTrustStoreCertificate = trustAnchor.getX509CertChain().get(0).decode();
         byte[] expectedTrustStoreCACertificate = trustAnchor.getX509CertChain().get(1).decode();
@@ -94,22 +103,23 @@ public class EidasMetadataResolverRepositoryTest {
         assertArrayEquals(expectedTrustStoreCertificate, actualTrustStoreCertificate);
         assertArrayEquals(expectedTrustStoreCACertificate, actualTrustStoreCACertificate);
         assertThat(metadataResolverConfiguration.getUri().toString()).isEqualTo("http://signin.gov.uk/entity/id");
+        assertThat(metadataResolverRepository.getSignatureTrustEngine(trustAnchor.getKeyID())).isEqualTo(explicitKeySignatureTrustEngine);
     }
 
     @Test
     public void shouldNotCreateMetadataResolverWhenCertificateIsInvalid() throws ParseException {
-        trustAnchors.add(createJWK("http://signin.gov.uk/entity-id", Collections.singletonList(TestCertificateStrings.UNCHAINED_PUBLIC_CERT)));
-        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer);
+        String entityId = "http://signin.gov.uk/entity-id";
+        trustAnchors.add(createJWK(entityId, Collections.singletonList(TestCertificateStrings.UNCHAINED_PUBLIC_CERT)));
+        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer, metadataSignatureTrustEngineFactory);
 
-        MetadataResolver createdMetadataResolver = metadataResolverRepository.getMetadataResolver("http://signin.gov.uk/entity-id");
-
-        assertThat(createdMetadataResolver).isNull();
+        assertThat(metadataResolverRepository.getMetadataResolver(entityId)).isNull();
+        assertThat(metadataResolverRepository.getSignatureTrustEngine(entityId)).isNull();
     }
 
     @Test
     public void shouldUpdateListOfMetadataResolversWhenRefreshing() throws ParseException {
         trustAnchors.add(createJWK("http://signin.gov.uk/entity-id", Collections.singletonList(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT)));
-        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer);
+        metadataResolverRepository = new EidasMetadataResolverRepository(trustAnchorResolver, environment, metadataConfiguration, dropwizardMetadataResolverFactory, timer, metadataSignatureTrustEngineFactory);
         when(environment.metrics()).thenReturn(new MetricRegistry());
 
         trustAnchors.remove(0);

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactoryTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactoryTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.saml.metadata.factories;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.criteria.UsageCriterion;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.metadata.test.factories.metadata.EntityDescriptorFactory;
+import uk.gov.ida.saml.metadata.test.factories.metadata.TestCredentialFactory;
+
+import java.security.PublicKey;
+
+public class CredentialResolverFactoryTest {
+
+    private static DOMMetadataResolver metadataResolver;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        InitializationService.initialize();
+
+        //has Hub's entity ID
+        EntityDescriptor entityDescriptor = new EntityDescriptorFactory().hubEntityDescriptor();
+        Element element = XMLObjectSupport.marshall(entityDescriptor);
+
+        metadataResolver = new DOMMetadataResolver(element);
+        metadataResolver.setId("test-metadata-resolver");
+        metadataResolver.initialize();
+    }
+
+    @Test
+    public void shouldSupportResolvingCredentialsFromKeysInMetadata() throws Exception {
+        MetadataCredentialResolver metadataCredentialResolver = new CredentialResolverFactory().create(metadataResolver);
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(new EntityIdCriterion(TestEntityIds.HUB_ENTITY_ID));
+        trustBasisCriteria.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
+        trustBasisCriteria.add(new UsageCriterion(UsageType.ENCRYPTION));
+
+        PublicKey publicKey = TestCredentialFactory.createPublicKey(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+        Assertions.assertThat(metadataCredentialResolver.resolveSingle(trustBasisCriteria).getPublicKey()).isEqualTo(publicKey);
+    }
+
+    @Test
+    public void shouldFailToResolveIfEnttiyIsNotFound() throws Exception {
+        MetadataCredentialResolver metadataCredentialResolver = new CredentialResolverFactory().create(metadataResolver);
+
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(new EntityIdCriterion(TestEntityIds.STUB_IDP_ONE));
+        trustBasisCriteria.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
+
+        Assertions.assertThat(metadataCredentialResolver.resolveSingle(trustBasisCriteria)).isNull();
+    }
+
+}

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactoryTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactoryTest.java
@@ -1,0 +1,104 @@
+package uk.gov.ida.saml.metadata.factories;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
+import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.security.credential.BasicCredential;
+import org.opensaml.security.crypto.KeySupport;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.impl.SignatureBuilder;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.opensaml.xmlsec.signature.support.Signer;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.metadata.test.factories.metadata.EntityDescriptorFactory;
+
+import javax.xml.crypto.dsig.CanonicalizationMethod;
+import javax.xml.crypto.dsig.SignatureMethod;
+import java.security.KeyException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPrivateKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MetadataSignatureTrustEngineFactoryTest {
+
+    private static DOMMetadataResolver metadataResolver;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        InitializationService.initialize();
+
+        //has Hub's entity ID
+        EntityDescriptor entityDescriptor = new EntityDescriptorFactory().hubEntityDescriptor();
+        Element element = XMLObjectSupport.marshall(entityDescriptor);
+
+        metadataResolver = new DOMMetadataResolver(element);
+        metadataResolver.setId("test-metadata-resolver");
+        metadataResolver.initialize();
+    }
+
+    @Test
+    public void shouldSupportValidatingSignaturesUsingKeysInMetadata() throws Exception {
+        SignatureTrustEngine signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(metadataResolver);
+
+        Signature signature = createSignatureInAuthnRequest(TestEntityIds.HUB_ENTITY_ID);
+
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(new EntityIdCriterion(TestEntityIds.HUB_ENTITY_ID));
+        trustBasisCriteria.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
+
+        assertThat(signatureTrustEngine.validate(signature, trustBasisCriteria)).isTrue();
+    }
+
+    @Test
+    public void shouldSupportInvalidatingSignaturesUsingKeysInMetadata() throws Exception {
+        SignatureTrustEngine signatureTrustEngine = new MetadataSignatureTrustEngineFactory().createSignatureTrustEngine(metadataResolver);
+
+        Signature signature = createSignatureInAuthnRequest(TestEntityIds.STUB_IDP_ONE);
+
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(new EntityIdCriterion(TestEntityIds.STUB_IDP_ONE));
+        trustBasisCriteria.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
+
+        assertThat(signatureTrustEngine.validate(signature, trustBasisCriteria)).isFalse();
+    }
+
+    private Signature createSignatureInAuthnRequest(String id) throws KeyException, SignatureException, MarshallingException {
+        Issuer issuer = new IssuerBuilder().buildObject();
+        issuer.setValue(id);
+
+        Signature signature = new SignatureBuilder().buildObject();
+        String privateKey = TestCertificateStrings.PRIVATE_SIGNING_KEYS.get(TestEntityIds.HUB_ENTITY_ID);
+
+        RSAPrivateKey rsaPrivateKey = KeySupport.buildJavaRSAPrivateKey(privateKey);
+        PublicKey publicKey = KeySupport.derivePublicKey(rsaPrivateKey);
+        BasicCredential newCredential = new BasicCredential(publicKey, rsaPrivateKey);
+        signature.setSigningCredential(newCredential);
+        signature.setSignatureAlgorithm(SignatureMethod.RSA_SHA1);
+        signature.setCanonicalizationAlgorithm(CanonicalizationMethod.EXCLUSIVE);
+
+        AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
+        authnRequest.setIssuer(issuer);
+        authnRequest.setSignature(signature);
+        XMLObjectSupport.marshall(authnRequest);
+        Signer.signObject(signature);
+        return  signature;
+    }
+
+}

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/EncryptionCredentialFactory.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/EncryptionCredentialFactory.java
@@ -5,8 +5,7 @@ import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.UsageType;
 
 
-
-public class EncryptionCredentialFactory {
+public class EncryptionCredentialFactory implements EncryptionCredentialResolver {
     private final EncryptionKeyStore encryptionKeyStore;
 
 
@@ -14,6 +13,7 @@ public class EncryptionCredentialFactory {
         this.encryptionKeyStore = encryptionKeyStore;
     }
 
+    @Override
     public Credential getEncryptingCredential(String receiverId) {
         BasicCredential credential = new BasicCredential(encryptionKeyStore.getEncryptionKeyForEntity(receiverId));
         credential.setUsageType(UsageType.ENCRYPTION);

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/EncryptionCredentialResolver.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/EncryptionCredentialResolver.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.security;
+
+import org.opensaml.security.credential.Credential;
+
+public interface EncryptionCredentialResolver {
+    Credential getEncryptingCredential(String receiverId);
+}

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolver.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolver.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.security;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.criteria.UsageCriterion;
+
+import javax.xml.namespace.QName;
+
+public class MetadataBackedEncryptionCredentialResolver implements EncryptionCredentialResolver {
+
+    private CredentialResolver credentialResolver;
+    private QName role;
+
+    public MetadataBackedEncryptionCredentialResolver(CredentialResolver credentialResolver, QName role) {
+        this.credentialResolver = credentialResolver;
+        this.role = role;
+    }
+
+    @Override
+    public Credential getEncryptingCredential(String receiverId) {
+        CriteriaSet criteria = new CriteriaSet();
+        criteria.add(new EntityIdCriterion(receiverId));
+        criteria.add(new EntityRoleCriterion(role));
+        criteria.add(new UsageCriterion(UsageType.ENCRYPTION));
+        try {
+            return credentialResolver.resolveSingle(criteria);
+        } catch (ResolverException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolverTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolverTest.java
@@ -1,0 +1,73 @@
+package uk.gov.ida.saml.security;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.xml.BasicParserPool;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.saml.metadata.resolver.impl.BasicRoleDescriptorResolver;
+import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.criteria.UsageCriterion;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.security.saml.TestCredentialFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.PublicKey;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class MetadataBackedEncryptionCredentialResolverTest {
+    private MetadataCredentialResolver metadataCredentialResolver;
+
+    @Before
+    public void beforeAll() throws Exception {
+        InitializationService.initialize();
+
+        StringBackedMetadataResolver metadataResolver = new StringBackedMetadataResolver(loadMetadata("metadata.xml"));
+        BasicParserPool basicParserPool = new BasicParserPool();
+        basicParserPool.initialize();
+        metadataResolver.setParserPool(basicParserPool);
+        metadataResolver.setRequireValidMetadata(true);
+        metadataResolver.setId("arbitrary id");
+        metadataResolver.initialize();
+
+        BasicRoleDescriptorResolver basicRoleDescriptorResolver = new BasicRoleDescriptorResolver(metadataResolver);
+        basicRoleDescriptorResolver.initialize();
+
+        metadataCredentialResolver = new MetadataCredentialResolver();
+        metadataCredentialResolver.setRoleDescriptorResolver(basicRoleDescriptorResolver);
+        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+        metadataCredentialResolver.initialize();
+    }
+
+    private String loadMetadata(String fileName) throws IOException {
+        URL authnRequestUrl = getClass().getClassLoader().getResource(fileName);
+        return Resources.toString(authnRequestUrl, Charsets.UTF_8);
+    }
+
+    @Test
+    public void shouldSupportResolvingCredentialsFromKeysInMetadata() throws Exception {
+        PublicKey publicKey = TestCredentialFactory.createPublicKey(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+        assertThat(new MetadataBackedEncryptionCredentialResolver(metadataCredentialResolver, SPSSODescriptor.DEFAULT_ELEMENT_NAME).getEncryptingCredential(TestEntityIds.HUB_ENTITY_ID).getPublicKey()).isEqualTo(publicKey);
+    }
+
+    @Test
+    public void shouldFailToResolveIfEnttiyIsNotFound() throws Exception {
+        assertThat(new MetadataBackedEncryptionCredentialResolver(metadataCredentialResolver, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).getEncryptingCredential(TestEntityIds.HUB_ENTITY_ID)).isNull();
+        assertThat(new MetadataBackedEncryptionCredentialResolver(metadataCredentialResolver, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).getEncryptingCredential(TestEntityIds.STUB_IDP_ONE)).isNull();
+    }
+
+}

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/saml/TestCredentialFactory.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/saml/TestCredentialFactory.java
@@ -64,7 +64,7 @@ public class TestCredentialFactory {
         return publicKey;
     }
 
-    private PublicKey createPublicKey(String partialCert) throws CertificateException, UnsupportedEncodingException {
+    public static PublicKey createPublicKey(String partialCert) throws CertificateException, UnsupportedEncodingException {
         CertificateFactory certificateFactory;
         certificateFactory = CertificateFactory.getInstance("X.509");
         String fullCert;


### PR DESCRIPTION
This PR introduces a bunch of new signature and encryption classes based around reading SAML metadata to support verifying or encrypting messages. The goal is to use these classes to reduce the duplication and complexity that we have in the rest of our codebase.

The main changes are:
- Added `MetadataSignatureTrustEngineFactory` which is used to generate `SignatureTrustEngine`s that validate XML signatures using credentials sourced from a `MetadataResolver`
- `MetadataResolverBundle` now creates a `SignatureTrustEngine` so that apps that use the bundle don't have to use the factory
- Using a `MetadataSignatureTrustEngineFactory` in the `EidasMetadataResolverRepository` so that the dynamic generated `MetadataResolver`s have accompanying `SignatureTrustEngine`s
- `CredentialResolverFactory` can be used to create `MetadataCredentialResolver`s using `MetadataResolver`s
- `MetadataResolverBundle` now creates a `MetadataCredentialResolver` so that apps that use the bundle don't have to use the factory
- Added `EncryptionCredentialResolver` interface and `MetadataBackedEncryptionCredentialResolver` so that we can use `MetadataCredentialResolver` to resolve credentials for encrypting
- Made it so that we can skip signature validation in `MetadataResolverBundle` so that the VSP can use it for reading MSA signatures
