### PR TITLE
firebreak: return Optional on fetching `MetadataResolver`

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
@@ -66,16 +66,16 @@ public class EidasMetadataResolverRepository {
         refresh();
     }
 
-    public MetadataResolver getMetadataResolver(String entityId) {
-        return Optional.ofNullable(metadataResolvers.get(entityId)).map(MetadataPair::getMetadataResolver).orElse(null);
+    public Optional<MetadataResolver> getMetadataResolver(String entityId) {
+        return Optional.ofNullable(metadataResolvers.get(entityId)).map(MetadataPair::getMetadataResolver);
     }
 
     public List<String> getEntityIdsWithResolver() {
         return metadataResolvers.keySet().asList();
     }
 
-    public ExplicitKeySignatureTrustEngine getSignatureTrustEngine(String entityId) {
-        return Optional.ofNullable(metadataResolvers.get(entityId)).map(MetadataPair::getSignatureTrustEngine).orElse(null);
+    public Optional<ExplicitKeySignatureTrustEngine> getSignatureTrustEngine(String entityId) {
+        return Optional.ofNullable(metadataResolvers.get(entityId)).map(MetadataPair::getSignatureTrustEngine);
     }
 
     public Map<String, MetadataResolver> getMetadataResolvers(){


### PR DESCRIPTION
The same applies when fetching the signature trust engine.