### PR TITLE
BAU: Metadata resolvers for eIDAS trust anchors have unique suffix

### DIFF
--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
@@ -15,9 +15,6 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;


### PR DESCRIPTION
The way that we recreate all resolvers then destroys the old one with the same names cause issues when trying to register metric. This change is to add a suffix with the current time in milliseconds.