### PR TITLE
bau: use EncryptionCredentialResolver in Encrypters

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/AbstractAssertionEncrypter.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/AbstractAssertionEncrypter.java
@@ -7,30 +7,30 @@ import org.opensaml.saml.saml2.encryption.Encrypter;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.encryption.support.EncryptionException;
 import uk.gov.ida.saml.security.EncrypterFactory;
-import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
+import uk.gov.ida.saml.security.EncryptionCredentialResolver;
 import uk.gov.ida.saml.security.EntityToEncryptForLocator;
 
 import java.util.List;
 
 public abstract class AbstractAssertionEncrypter<T> {
-    protected final KeyStoreBackedEncryptionCredentialResolver credentialFactory;
+    protected final EncryptionCredentialResolver credentialResolver;
     protected final EncrypterFactory encrypterFactory;
     protected final EntityToEncryptForLocator entityToEncryptForLocator;
 
     public AbstractAssertionEncrypter(
             final EncrypterFactory encrypterFactory,
             final EntityToEncryptForLocator entityToEncryptForLocator,
-            final KeyStoreBackedEncryptionCredentialResolver credentialFactory) {
+            final EncryptionCredentialResolver credentialResolver) {
 
         this.encrypterFactory = encrypterFactory;
         this.entityToEncryptForLocator = entityToEncryptForLocator;
-        this.credentialFactory = credentialFactory;
+        this.credentialResolver = credentialResolver;
     }
 
     public T encryptAssertions(T samlMessage) {
         if (getAssertions(samlMessage).size() > 0) {
             String entityToEncryptFor = entityToEncryptForLocator.fromRequestId(getRequestId(samlMessage));
-            Credential credential = credentialFactory.getEncryptingCredential(entityToEncryptFor);
+            Credential credential = credentialResolver.getEncryptingCredential(entityToEncryptFor);
 
             Encrypter samlEncrypter = encrypterFactory.createEncrypter(credential);
 

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlResponseAssertionEncrypter.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlResponseAssertionEncrypter.java
@@ -4,6 +4,7 @@ import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionCredentialResolver;
 import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
 import uk.gov.ida.saml.security.EntityToEncryptForLocator;
 
@@ -14,10 +15,10 @@ public class SamlResponseAssertionEncrypter extends AbstractAssertionEncrypter<R
 
     @Inject
     public SamlResponseAssertionEncrypter(
-            KeyStoreBackedEncryptionCredentialResolver credentialFactory,
+            EncryptionCredentialResolver credentialResolver,
             EncrypterFactory encrypterFactory,
             EntityToEncryptForLocator entityToEncryptForLocator) {
-        super(encrypterFactory, entityToEncryptForLocator, credentialFactory);
+        super(encrypterFactory, entityToEncryptForLocator, credentialResolver);
 
     }
 


### PR DESCRIPTION
Use the more generic EncryptionCredentialResolver in our encrypters so
that we can also use the MetadataEncryptionCredentialResolver for
resolving credentials.