### PR TITLE
EID-476 - Use latest Trust Anchor lib which now validate all x509 certs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
         opensaml_version = "3.3.0"
         dropwizard_version = "1.2.0"
         ida_utils_version = '332'
-        trust_anchor_version = '1.0-19'
+        trust_anchor_version = '1.0-21'
     }
     group = "uk.gov.ida"
     version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
@@ -67,7 +67,7 @@ subprojects {
                 'org.assertj:assertj-joda-time:1.1.0',
                 'org.assertj:assertj-core:1.6.0',
                 'junit:junit:4.11',
-                'uk.gov.ida:ida-dev-pki:1.1.0-22',
+                'uk.gov.ida:ida-dev-pki:1.1.0-25',
                 'org.mockito:mockito-core:1.9.5'
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"


### PR DESCRIPTION
- The eidas-trust-anchor lib now checks that all certs are valid.
- EidasMetadataResolverRepository now uses the earliest date of all certs instead
of the first cert.

Co-authored-by: Hoque Ali <hoque.ali@digital.cabinet-office.gov.uk>
Co-authored-by: Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>