### PR TITLE
BAU: Remove unnecessary exceptions from Certificate Chain Validation filter

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/EntityDescriptorListEmptyException.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/EntityDescriptorListEmptyException.java
@@ -1,8 +1,0 @@
-package uk.gov.ida.saml.metadata.exception;
-
-public class EntityDescriptorListEmptyException extends Exception {
-
-    public EntityDescriptorListEmptyException(final String message) {
-        super(message);
-    }
-}

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/KeyDescriptorListEmptyException.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/KeyDescriptorListEmptyException.java
@@ -1,8 +1,0 @@
-package uk.gov.ida.saml.metadata.exception;
-
-public class KeyDescriptorListEmptyException extends Exception {
-
-    public KeyDescriptorListEmptyException(final String message) {
-        super(message);
-    }
-}

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/RoleDescriptorListEmptyException.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/RoleDescriptorListEmptyException.java
@@ -1,8 +1,0 @@
-package uk.gov.ida.saml.metadata.exception;
-
-public class RoleDescriptorListEmptyException extends Exception {
-
-    public RoleDescriptorListEmptyException(final String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
Exceptions are only for error reporting and handling and should not be used for other purposes like control flow.

Authors: @adityapahuja