### PR TITLE
BAU: Add UsageCriterion for signing to MetadataBackedSignatureValidator

### DIFF
--- a/saml-metadata-bindings-test/src/main/java/uk/gov/ida/saml/metadata/test/factories/metadata/EntityDescriptorFactory.java
+++ b/saml-metadata-bindings-test/src/main/java/uk/gov/ida/saml/metadata/test/factories/metadata/EntityDescriptorFactory.java
@@ -60,6 +60,30 @@ public class EntityDescriptorFactory {
         }
     }
 
+    public EntityDescriptor hubEntityDescriptorWithWrongUsageCertificates() {
+        KeyDescriptor wrongUsageKeyDescriptorOne = createKeyDescriptor(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT, SIGNING_ONE, ENCRYPTION_USAGE);
+        KeyDescriptor wrongUsageKeyDescriptorTwo = createKeyDescriptor(TestCertificateStrings.HUB_TEST_SECONDARY_PUBLIC_SIGNING_CERT, SIGNING_TWO, ENCRYPTION_USAGE);
+        KeyDescriptor encryptionKeyDescriptorThree = createKeyDescriptor(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT, ENCRYPTION, ENCRYPTION_USAGE);
+        SPSSODescriptor spssoDescriptor = SPSSODescriptorBuilder.anSpServiceDescriptor()
+                .addKeyDescriptor(wrongUsageKeyDescriptorOne)
+                .addKeyDescriptor(wrongUsageKeyDescriptorTwo)
+                .addKeyDescriptor(encryptionKeyDescriptorThree)
+                .withoutDefaultSigningKey()
+                .withoutDefaultEncryptionKey().build();
+        try {
+            return EntityDescriptorBuilder.anEntityDescriptor()
+                    .withEntityId(TestEntityIds.HUB_ENTITY_ID)
+                    .addSpServiceDescriptor(spssoDescriptor)
+                    .withIdpSsoDescriptor(null)
+                    .withValidUntil(DateTime.now().plusWeeks(2))
+                    .withSignature(null)
+                    .withoutSigning()
+                    .build();
+        } catch (MarshallingException | SignatureException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
     private KeyDescriptor createKeyDescriptor(final String testCertificateString, final String keyName, final String usage) {
         X509Certificate x509Certificate = X509CertificateBuilder.aX509Certificate().withCert(testCertificateString).build();
         X509Data x509Data = X509DataBuilder.aX509Data().withX509Certificate(x509Certificate).build();

--- a/saml-security/build.gradle
+++ b/saml-security/build.gradle
@@ -3,5 +3,6 @@ dependencies {
             configurations.security,
             project(':saml-extensions')
 
-    testCompile configurations.test_deps
+    testCompile configurations.test_deps,
+        project(':saml-metadata-bindings-test')
 }

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/MetadataBackedSignatureValidator.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/MetadataBackedSignatureValidator.java
@@ -3,6 +3,8 @@ package uk.gov.ida.saml.security;
 import net.shibboleth.utilities.java.support.resolver.Criterion;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.criteria.UsageCriterion;
 import org.opensaml.security.trust.TrustEngine;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
@@ -40,6 +42,7 @@ public class MetadataBackedSignatureValidator extends SignatureValidator {
         List<Criterion> criteriaSet = new ArrayList<>();
         criteriaSet.add(new EntityIdCriterion(entityId));
         criteriaSet.add(new EntityRoleCriterion(role));
+        criteriaSet.add(new UsageCriterion(UsageType.SIGNING));
         this.certificateChainEvaluableCriteria.map(criteriaSet::add);
 
         return criteriaSet;


### PR DESCRIPTION
Add an additional criterion to ensure only signing certificates are used for signature validation.

Co-Authored-by: Aditya Pahuja <aditya.pahuja@digital.cabinet-office.gov.uk>