### PR TITLE
EID-467: Use TransliterableMdsValue for names in MatchingDataset

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/MatchingDataset.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/MatchingDataset.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 
 public class MatchingDataset {
 
-    private final List<SimpleMdsValue<String>> firstNames;
+    private final List<TransliterableMdsValue> firstNames;
     private final List<SimpleMdsValue<String>> middleNames;
-    private final List<SimpleMdsValue<String>> surnames;
+    private final List<TransliterableMdsValue> surnames;
     private final Optional<SimpleMdsValue<Gender>> gender;
     private final List<SimpleMdsValue<LocalDate>> dateOfBirths;
     private final List<Address> currentAddresses;
@@ -19,9 +19,9 @@ public class MatchingDataset {
     private final String personalId;
 
     public MatchingDataset(
-            List<SimpleMdsValue<String>> firstNames,
+            List<TransliterableMdsValue> firstNames,
             List<SimpleMdsValue<String>> middleNames,
-            List<SimpleMdsValue<String>> surnames,
+            List<TransliterableMdsValue> surnames,
             Optional<SimpleMdsValue<Gender>> gender,
             List<SimpleMdsValue<LocalDate>> dateOfBirths,
             List<Address> currentAddresses,
@@ -37,7 +37,7 @@ public class MatchingDataset {
         this.personalId = personalId;
     }
 
-    public List<SimpleMdsValue<String>> getFirstNames() {
+    public List<TransliterableMdsValue> getFirstNames() {
         return firstNames;
     }
 
@@ -45,7 +45,7 @@ public class MatchingDataset {
         return middleNames;
     }
 
-    public List<SimpleMdsValue<String>> getSurnames() {
+    public List<TransliterableMdsValue> getSurnames() {
         return surnames;
     }
 

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/TransliterableMdsValue.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/TransliterableMdsValue.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.core.domain;
+
+public class TransliterableMdsValue extends SimpleMdsValue<String> {
+    private String nonLatinScriptValue;
+
+    public TransliterableMdsValue(String value, String nonLatinScriptValue) {
+        super(value, null, null, true);
+        this.nonLatinScriptValue = nonLatinScriptValue;
+    }
+
+    public TransliterableMdsValue(SimpleMdsValue<String> simpleMdsValue) {
+        super(simpleMdsValue.getValue(), simpleMdsValue.getFrom(), simpleMdsValue.getTo(), simpleMdsValue.isVerified());
+        this.nonLatinScriptValue = null;
+    }
+
+    public String getNonLatinScriptValue() {
+        return nonLatinScriptValue;
+    }
+}

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
@@ -7,18 +7,20 @@ import uk.gov.ida.saml.core.domain.AddressFactory;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 
 public class MatchingDatasetBuilder {
 
-    private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+    private List<TransliterableMdsValue> firstnames = new ArrayList<>();
     private List<SimpleMdsValue<String>> middleNames = new ArrayList<>();
-    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private List<TransliterableMdsValue> surnames = new ArrayList<>();
     private Optional<SimpleMdsValue<Gender>> gender = Optional.empty();
     private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
     private List<Address> currentAddresses = new ArrayList<>();
@@ -48,7 +50,7 @@ public class MatchingDatasetBuilder {
     }
 
     public MatchingDatasetBuilder addFirstname(SimpleMdsValue<String> firstname) {
-        this.firstnames.add(firstname);
+        this.firstnames.add(new TransliterableMdsValue(firstname));
         return this;
     }
 
@@ -58,7 +60,7 @@ public class MatchingDatasetBuilder {
     }
 
     public MatchingDatasetBuilder addSurname(SimpleMdsValue<String> surname) {
-        this.surnames.add(surname);
+        this.surnames.add(new TransliterableMdsValue(surname));
         return this;
     }
 
@@ -111,7 +113,7 @@ public class MatchingDatasetBuilder {
             final List<SimpleMdsValue<String>> surnameHistory) {
 
         this.surnames.clear();
-        this.surnames.addAll(surnameHistory);
+        this.surnames.addAll(surnameHistory.stream().map(TransliterableMdsValue::new).collect(Collectors.toList()));
         return this;
     }
 }

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/MatchingDatasetBuilder.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/MatchingDatasetBuilder.java
@@ -5,6 +5,7 @@ import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,20 +14,20 @@ import java.util.Optional;
 import static com.google.common.collect.Lists.newArrayList;
 
 class MatchingDatasetBuilder {
-    private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+    private List<TransliterableMdsValue> firstnames = new ArrayList<>();
     private List<SimpleMdsValue<String>> middlenames = new ArrayList<>();
-    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private List<TransliterableMdsValue> surnames = new ArrayList<>();
     private Optional<SimpleMdsValue<Gender>> gender = Optional.empty();
     private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
     private List<Address> currentAddresses = newArrayList();
     private List<Address> previousAddresses = newArrayList();
     private String personalId;
 
-    public void firstname(List<SimpleMdsValue<String>> firstnames) {
+    public void addFirstNames(List<TransliterableMdsValue> firstnames) {
         this.firstnames.addAll(firstnames);
     }
 
-    public void addSurnames(List<SimpleMdsValue<String>> surnames) {
+    public void addSurnames(List<TransliterableMdsValue> surnames) {
         this.surnames.addAll(surnames);
     }
 

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/VerifyMatchingDatasetUnmarshaller.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/VerifyMatchingDatasetUnmarshaller.java
@@ -10,10 +10,12 @@ import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.AddressFactory;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
 import uk.gov.ida.saml.core.extensions.PersonName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
@@ -29,7 +31,7 @@ public class VerifyMatchingDatasetUnmarshaller extends MatchingDatasetUnmarshall
     protected void transformAttribute(Attribute attribute, MatchingDatasetBuilder datasetBuilder) {
         switch (attribute.getName()) {
             case IdaConstants.Attributes_1_1.Firstname.NAME:
-                datasetBuilder.firstname(transformPersonNameAttribute(attribute));
+                datasetBuilder.addFirstNames(transformPersonNameAttribute(attribute).stream().map(TransliterableMdsValue::new).collect(Collectors.toList()));
                 break;
 
             case IdaConstants.Attributes_1_1.Middlename.NAME:
@@ -37,7 +39,7 @@ public class VerifyMatchingDatasetUnmarshaller extends MatchingDatasetUnmarshall
                 break;
 
             case IdaConstants.Attributes_1_1.Surname.NAME:
-                datasetBuilder.addSurnames(transformPersonNameAttribute(attribute));
+                datasetBuilder.addSurnames(transformPersonNameAttribute(attribute).stream().map(TransliterableMdsValue::new).collect(Collectors.toList()));
                 break;
 
             case IdaConstants.Attributes_1_1.Gender.NAME:


### PR DESCRIPTION
We want to use a single MatchingDataset to represent all matching data
from both Verify and eIDAS. We need to allow for having non-latin script
values when handling eIDAS. This expands the MatchingDataset class (and
it's members) to allow it to store these values