### PR TITLE
Bau publish saml libs to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,10 @@ subprojects {
         dropwizard_version = "1.2.0"
         ida_utils_version = '332'
         trust_anchor_version = '1.0-31'
+        build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"
-    version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+    version = "$build_version"
 
     repositories {
         maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }

--- a/build.jenkins
+++ b/build.jenkins
@@ -33,9 +33,13 @@
                 // Artifactory credentials
                 ARTIUSER = "${env.ARTIFACTORYUSER}"
                 ARTIPASSWORD = "${env.ARTIFACTORYPASSWORD}"
+                // Bintray credentials
+                BINTRAY_USER    = 'richardtowers'
+                BINTRAY_API_KEY = credentials('bintray-api-key')
             }
             steps {
                 sh './gradlew publish'
+                sh './gradlew :saml-serializers:bintrayUpload'
             }
         }
     }

--- a/build.jenkins
+++ b/build.jenkins
@@ -38,8 +38,7 @@
                 BINTRAY_API_KEY = credentials('bintray-api-key')
             }
             steps {
-                sh './gradlew publish'
-                sh './gradlew :saml-serializers:bintrayUpload'
+                sh './gradlew publish bintrayUpload'
             }
         }
     }

--- a/saml-extensions/build.gradle
+++ b/saml-extensions/build.gradle
@@ -1,3 +1,4 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             configurations.slf4j,
@@ -5,3 +6,21 @@ dependencies {
 
     testCompile configurations.test_deps
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-extensions'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+

--- a/saml-metadata-bindings-test/build.gradle
+++ b/saml-metadata-bindings-test/build.gradle
@@ -1,5 +1,24 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             configurations.xml_utils,
             project(':saml-serializers')
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-metadata-bindings-test'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+

--- a/saml-metadata-bindings/build.gradle
+++ b/saml-metadata-bindings/build.gradle
@@ -1,3 +1,4 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             configurations.dropwizard,
@@ -7,3 +8,21 @@ dependencies {
     testCompile configurations.test_deps,
             project(':saml-metadata-bindings-test')
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-metadata-bindings'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+

--- a/saml-security/build.gradle
+++ b/saml-security/build.gradle
@@ -1,3 +1,4 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             configurations.security,
@@ -6,3 +7,21 @@ dependencies {
     testCompile configurations.test_deps,
         project(':saml-metadata-bindings-test')
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-security'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+

--- a/saml-serializers/build.gradle
+++ b/saml-serializers/build.gradle
@@ -1,3 +1,4 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             project(':saml-extensions')
@@ -5,3 +6,21 @@ dependencies {
     testCompile configurations.test_deps,
                 configurations.opensaml
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-serializers'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+

--- a/saml-utils/build.gradle
+++ b/saml-utils/build.gradle
@@ -1,6 +1,25 @@
+plugins { id "com.jfrog.bintray" version "1.8.0" }
 dependencies {
     compile configurations.opensaml,
             project(':saml-extensions'),
             project(':saml-serializers'),
             project(':saml-security')
 }
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['mavenJava']
+    publish = true
+    pkg {
+        repo = 'maven-test'
+        name = 'ida-saml-utils'
+        userOrg = 'alphagov'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/alphagov/verify-saml-libs.git'
+        version {
+            name = "$build_version"
+        }
+    }
+}
+


### PR DESCRIPTION
The `bintray` plugin is a bit fussy about the `publications` key - it needs to point at `mavenJava` for the subproject, and I wasn't sure how to achieve this. Hence the duplication of the bintray block.

Hopefully should be simple enough.