### PR TITLE
bau: Enable builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+matrix:
+  allow_failures:
+  - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ jdk:
   - openjdk8
 matrix:
   allow_failures:
+  - jdk: openjdk8
   - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,11 @@ matrix:
   allow_failures:
   - jdk: openjdk8
   - jdk: oraclejdk9
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Verify SAML Libraries 📚
 ========================
 
+[![Build Status](https://travis-ci.org/alphagov/verify-saml-libs.svg?branch=master)](https://travis-ci.org/alphagov/verify-saml-libs)
+
 The individual SAML libraries used by Verify have been combined in this repository to make managing dependencies easier.
 
 Affected libraries:

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ subprojects {
     ext {
         opensaml_version = "3.3.0"
         dropwizard_version = "1.2.0"
-        ida_utils_version = '332'
-        trust_anchor_version = '1.0-31'
+        ida_utils_version = '335'
+        trust_anchor_version = '1.0-34'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects {
                 "uk.gov.ida.eidas:trust-anchor:$trust_anchor_version",
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
-        test_deps 'uk.gov.ida:common-test-utils:2.0.0-41',
+        test_deps 'uk.gov.ida:common-test-utils:2.0.0-43',
                 "com.github.tomakehurst:wiremock-standalone:2.16.0",
                 "io.dropwizard:dropwizard-testing:$dropwizard_version",
                 'org.hamcrest:hamcrest-library:1.3',

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,13 @@ apply from: 'publish.gradle'
 
 buildscript {
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
@@ -26,7 +32,14 @@ subprojects {
     version = "$build_version"
 
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
 
     configurations {


### PR DESCRIPTION
Bumps a few library versions to the recent builds which are available on bintray.