### PR TITLE
49: Upgrade Dropwizard to 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ subprojects {
 
     ext {
         opensaml_version = "3.3.0"
-        dropwizard_version = "1.2.0"
-        ida_utils_version = '335'
+        dropwizard_version = "1.3.5"
+        ida_utils_version = '337'
         trust_anchor_version = '1.0-34'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
@@ -60,7 +60,7 @@ subprojects {
 
         dropwizard "io.dropwizard:dropwizard-core:$dropwizard_version",
                 "io.dropwizard:dropwizard-client:$dropwizard_version",
-                'io.dropwizard:dropwizard-jackson:1.0.5'
+                "io.dropwizard:dropwizard-jackson:$dropwizard_version"
 
         opensaml "org.opensaml:opensaml-core:$opensaml_version",
                 "org.opensaml:opensaml-saml-impl:$opensaml_version",
@@ -74,7 +74,7 @@ subprojects {
                 "uk.gov.ida.eidas:trust-anchor:$trust_anchor_version",
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
-        test_deps 'uk.gov.ida:common-test-utils:2.0.0-43',
+        test_deps "uk.gov.ida:common-test-utils:2.0.0-44",
                 "com.github.tomakehurst:wiremock-standalone:2.16.0",
                 "io.dropwizard:dropwizard-testing:$dropwizard_version",
                 'org.hamcrest:hamcrest-library:1.3',


### PR DESCRIPTION
Upgrade Dropwizard to 1.3.5 to fix various security issues.

Authors: @adityapahuja