### PR TITLE
EID-811: Add support for additional eIDAS signing algorithms

### DIFF
--- a/saml-extensions/src/main/java/uk/gov/ida/saml/core/EidasSecurityConfigurationInitializer.java
+++ b/saml-extensions/src/main/java/uk/gov/ida/saml/core/EidasSecurityConfigurationInitializer.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core;
+
+import org.apache.xml.security.signature.XMLSignature;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.opensaml.core.config.ConfigurationService;
+import org.opensaml.core.config.Initializer;
+import org.opensaml.xmlsec.SignatureValidationConfiguration;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.impl.BasicSignatureValidationConfiguration;
+
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EidasSecurityConfigurationInitializer implements Initializer {
+    @Override
+    public void init() {
+        Security.addProvider(new BouncyCastleProvider());
+        BasicSignatureValidationConfiguration signatureValidationConfiguration = DefaultSecurityConfigurationBootstrap.buildDefaultSignatureValidationConfiguration();
+        Collection<String> defaultAlgos = signatureValidationConfiguration.getWhitelistedAlgorithms();
+        Collection<String> customAlgos = Arrays.asList(
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1
+        );
+        signatureValidationConfiguration.setWhitelistedAlgorithms(Stream.concat(defaultAlgos.stream(), customAlgos.stream()).collect(Collectors.toList()));
+        ConfigurationService.register(SignatureValidationConfiguration.class, signatureValidationConfiguration);
+    }
+}

--- a/saml-extensions/src/main/resources/META-INF/org.opensaml.core.config.Initializer
+++ b/saml-extensions/src/main/resources/META-INF/org.opensaml.core.config.Initializer
@@ -1,0 +1,1 @@
+uk.gov.ida.saml.core.EidasSecurityConfigurationInitializer

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProvider.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProvider.java
@@ -2,6 +2,7 @@ package uk.gov.ida.saml.metadata;
 
 import com.google.common.base.Throwables;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.opensaml.saml.metadata.resolver.filter.impl.SignatureValidationFilter;
 import org.opensaml.security.x509.impl.BasicPKIXValidationInformation;
 import org.opensaml.xmlsec.SignatureValidationParameters;
@@ -17,6 +18,7 @@ import javax.inject.Provider;
 import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -25,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.apache.xml.security.signature.XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1;
 import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_DIGEST_SHA256;
 import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_DIGEST_SHA512;
 import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_ECDSA_SHA256;
@@ -49,18 +52,19 @@ public class PKIXSignatureValidationFilterProvider implements Provider<Signature
             ALGO_ID_DIGEST_SHA512,
             ALGO_ID_SIGNATURE_ECDSA_SHA256,
             ALGO_ID_SIGNATURE_ECDSA_SHA384,
-            ALGO_ID_SIGNATURE_ECDSA_SHA512
+            ALGO_ID_SIGNATURE_ECDSA_SHA512,
+            ALGO_ID_SIGNATURE_RSA_SHA256_MGF1
     );
     private KeyStore metadataTrustStore;
 
     @Inject
     public PKIXSignatureValidationFilterProvider(@Named("metadataTruststore") KeyStore metadataTrustStore) {
+        Security.addProvider(new BouncyCastleProvider());
         this.metadataTrustStore = metadataTrustStore;
     }
 
     @Override
     public SignatureValidationFilter get() {
-
         ArrayList<String> aliases;
         BasicPKIXValidationInformation basicPKIXValidationInformation = null;
         try {

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/SignatureValidator.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/SignatureValidator.java
@@ -2,6 +2,7 @@ package uk.gov.ida.saml.security;
 
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.Criterion;
+import org.apache.xml.security.signature.XMLSignature;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
 import org.opensaml.security.SecurityException;
@@ -39,7 +40,9 @@ public abstract class SignatureValidator {
 
                 SignatureConstants.ALGO_ID_DIGEST_SHA1,
                 SignatureConstants.ALGO_ID_DIGEST_SHA256,
-                SignatureConstants.ALGO_ID_DIGEST_SHA512
+                SignatureConstants.ALGO_ID_DIGEST_SHA512,
+
+                XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1
         ));
         criteria.add(new SignatureValidationParametersCriterion(signatureValidationParameters));
 


### PR DESCRIPTION
The eIDAS SAML Crypto specification allows only two cryptographic
algorithms to be used for signing SAML messages and metadata. One of
these (ECDSA) is already in the default OpenSAML
SignatureValidationConfiguration whitelist and just needed to be
whitelisted in `PKIXSignatureValidationFilterProvider` and
`SignatureValidator`. The other algorithm (RSASSA-PSS) is not in the
default OpenSAML whitelist and isn't supported natively by the Oracle
security providers.

The following changes are included:

- Add the BouncyCastle JCE Provider to the list of Java security
providers.
- Add an `EidasSecurityConfigurationInitializer` which uses the OpenSAML
`Initializer` interface and `InitializationService` mechanism to set
things up.
- Whitelist the RSASSA-PSS (sha256-rsa-MGF1) algorithm in
`PKIXSignatureValidationFilterProvider` and `SignatureValidator`.

Author: @vixus0