### PR TITLE
EID-820 - Support validating against a key transport algorithm whitelist

### DIFF
--- a/saml-security/src/main/java/uk/gov/ida/saml/security/validators/encryptedelementtype/EncryptionAlgorithmValidator.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/validators/encryptedelementtype/EncryptionAlgorithmValidator.java
@@ -12,13 +12,16 @@ import java.util.Set;
 
 public class EncryptionAlgorithmValidator {
     private final Set<String> algorithmWhitelist;
+    private final Set<String> keyTransportAlgorithmWhitelist;
 
     public EncryptionAlgorithmValidator() {
         this.algorithmWhitelist = ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128);
+        this.keyTransportAlgorithmWhitelist = ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP);
     }
 
-    public EncryptionAlgorithmValidator(Set<String> algorithmWhitelist) {
+    public EncryptionAlgorithmValidator(Set<String> algorithmWhitelist, Set<String> keyTransportAlgorithmWhitelist) {
         this.algorithmWhitelist = algorithmWhitelist;
+        this.keyTransportAlgorithmWhitelist = keyTransportAlgorithmWhitelist;
     }
 
     public void validate(EncryptedElementType encryptedElement) {
@@ -39,7 +42,7 @@ public class EncryptionAlgorithmValidator {
         }
 
         final String keyTransportAlgorithm = encryptionMethod.getAlgorithm();
-        if (!keyTransportAlgorithm.equals(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP)) {
+        if (!keyTransportAlgorithmWhitelist.contains(keyTransportAlgorithm)) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.unsupportedKeyEncryptionAlgorithm(keyTransportAlgorithm);
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/validators/encryptedelementtype/EncryptionAlgorithmValidatorTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/validators/encryptedelementtype/EncryptionAlgorithmValidatorTest.java
@@ -37,7 +37,9 @@ public class EncryptionAlgorithmValidatorTest {
     public void validate_shouldNotThrowSamlExceptionIfEncryptionAlgorithmIsWhitelisted() throws Exception {
         String algoIdBlockcipherAes256 = EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256;
         Set whitelistedAlgos = ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128, algoIdBlockcipherAes256);
-        validator = new EncryptionAlgorithmValidator(whitelistedAlgos);
+        Set whitelistedKeyTransportAlgos = ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11);
+
+        validator = new EncryptionAlgorithmValidator(whitelistedAlgos, whitelistedKeyTransportAlgos);
         validator.validate(createStandardEncryptedAssertion(algoIdBlockcipherAes256, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP, true));
         validator.validate(createOtherTypeOfEncryptedAssertion(algoIdBlockcipherAes256, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP));
     }
@@ -50,6 +52,16 @@ public class EncryptionAlgorithmValidatorTest {
         validateException(
                 SamlTransformationErrorFactory.unsupportedEncryptionAlgortithm(encryptionAlgorithm),
                 standardEncryptedAssertion);
+    }
+
+    @Test
+    public void validate_shouldNotThrowIfKeyTransportAlgorithmIsInWhitelist() throws Exception {
+        Set whitelistedAlgos = ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128);
+        Set whiteListedKeyTransportAlgos = ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSA15, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP);
+
+        validator = new EncryptionAlgorithmValidator(whitelistedAlgos, whiteListedKeyTransportAlgos);
+        validator.validate(createStandardEncryptedAssertion(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSA15, true));
+        validator.validate(createOtherTypeOfEncryptedAssertion(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSA15));
     }
 
     @Test


### PR DESCRIPTION
- eIDAS crypto spec mandates both RSA OAEP MGF1P and XMLENC11 RSA OAEP.
  Encryption validator currently only supports the former and we want
  to retain this behaviour for Verify, so add the ability to specify
  at construction which key transport algorithms we will support.
- The MSA retains the same behaviour as it only needs to support the algorithms which encrypt it 
in the HUB. Therefore the only other change will be to pass in the correct algorithms in the HUB. 

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>