### PR TITLE
EID-835 - Create RSASSA-PSS signature to sign stub country

### DIFF
--- a/saml-security/src/main/java/uk/gov/ida/saml/security/signature/SignatureRSASSAPSS.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/signature/SignatureRSASSAPSS.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.security.signature;
+
+import org.apache.xml.security.signature.XMLSignature;
+import org.opensaml.security.crypto.JCAConstants;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+
+import javax.annotation.Nonnull;
+
+public final class SignatureRSASSAPSS implements SignatureAlgorithm {
+
+    /** {@inheritDoc} */
+    @Nonnull public String getKey() {
+        return JCAConstants.KEY_ALGO_RSA;
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull public String getURI() {
+        return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1;
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull public AlgorithmType getType() {
+        return AlgorithmType.Signature;
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull public String getJCAAlgorithmID() {
+        return "RSAwithSHA256andMGF1";
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull public String getDigest() {
+        return JCAConstants.DIGEST_SHA256;
+    }
+
+}


### PR DESCRIPTION
-eidas crypto spec states that we should be supporting the RSASSA-PSS signature. This
isn't supplied by opensaml, so creating the signature object so we can
sign stub country assertion with this algorithm.

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>