### PR TITLE
EID-820 - Specify key transport algorithm when building saml response

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionBuilder.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionBuilder.java
@@ -216,17 +216,27 @@ public class AssertionBuilder {
         return buildWithEncrypterCredential(createEncrypter(credential, encryptionAlgorithm));
     }
 
+    public EncryptedAssertion buildWithEncrypterCredential(Credential credential,
+                                                           String encryptionAlgorithm,
+                                                           String keyTransportEncryptionAlgorithm) {
+        return buildWithEncrypterCredential(createEncrypter(credential, encryptionAlgorithm, keyTransportEncryptionAlgorithm));
+    }
+
     public Encrypter createEncrypter(Credential credential) {
         return createEncrypter(credential, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128);
     }
 
     public Encrypter createEncrypter(Credential credential, String encryptionAlgorithm) {
+        return createEncrypter(credential, encryptionAlgorithm, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP);
+    }
+
+    public Encrypter createEncrypter(Credential credential, String encryptionAlgorithm, String keyTransportEncryptionAlgorithm) {
         DataEncryptionParameters encParams = new DataEncryptionParameters();
         encParams.setAlgorithm(encryptionAlgorithm);
 
         KeyEncryptionParameters kekParams = new KeyEncryptionParameters();
         kekParams.setEncryptionCredential(credential);
-        kekParams.setAlgorithm(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP);
+        kekParams.setAlgorithm(keyTransportEncryptionAlgorithm);
 
         Encrypter encrypter = new Encrypter(encParams, kekParams);
         encrypter.setKeyPlacement(Encrypter.KeyPlacement.PEER);


### PR DESCRIPTION
- As eidas can support multiple key transport algorithms, we want to be able to test that the hub can accept a response with each algorithm
- Will allow to build a saml response with a specific key transport algorithm