### PR TITLE
EID-939 - Fix test and SignatureFactory code

### DIFF
--- a/saml-security/src/main/java/uk/gov/ida/saml/security/SignatureFactory.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/SignatureFactory.java
@@ -23,7 +23,6 @@ public class SignatureFactory {
     private final DigestAlgorithm digestAlgorithm;
     private final boolean includeKeyInfo;
 
-
     public SignatureFactory(IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever, SignatureAlgorithm signatureAlgorithm, DigestAlgorithm digestAlgorithm) {
         this(false, keyStoreCredentialRetriever, signatureAlgorithm, digestAlgorithm);
     }
@@ -42,9 +41,9 @@ public class SignatureFactory {
                 .getBuilder(Signature.DEFAULT_ELEMENT_NAME)
                 .buildObject(Signature.DEFAULT_ELEMENT_NAME);
 
-        if (includeKeyInfo && signingCertificate != null) {
+        if (includeKeyInfo) {
             if (signingCertificate == null) {
-                throw new IllegalStateException("Unable to generate key info without a signing certificate");
+                throw new SamlTransformationErrorException("Unable to generate key info without a signing certificate", Level.ERROR);
             }
             X509KeyInfoGeneratorFactory x509KeyInfoGeneratorFactory = new X509KeyInfoGeneratorFactory();
             x509KeyInfoGeneratorFactory.setEmitEntityCertificate(true);

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/SignatureFactoryTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/SignatureFactoryTest.java
@@ -1,0 +1,40 @@
+package uk.gov.ida.saml.security;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SignatureFactoryTest {
+
+    @Mock
+    private IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever;
+
+    @Mock
+    private SignatureAlgorithm signatureAlgorithm;
+
+    @Mock
+    private DigestAlgorithm digestAlgorithm;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldThrowExceptionWhenNoSigningCerts() {
+        expectedException.expectMessage("Unable to generate key info without a signing certificate");
+
+        SignatureFactory signatureFactory = new SignatureFactory(true, idaKeyStoreCredentialRetriever, signatureAlgorithm, digestAlgorithm);
+
+        when(idaKeyStoreCredentialRetriever.getSigningCredential()).thenReturn(null);
+        when(idaKeyStoreCredentialRetriever.getSigningCertificate()).thenReturn(null);
+
+        signatureFactory.createSignature();
+    }
+}


### PR DESCRIPTION
- A NullCheck which was added means that it will never throw when
KeyInfo is required but a signing cert is not there.
- Change it so that if KeyInfo is required but a
signing cert is not present, then throw exception.