### PR TITLE
BAU: Change test behaviour when no Eidas Metadata.

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheck.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheck.java
@@ -10,6 +10,7 @@ import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,18 +26,17 @@ public class EidasTrustAnchorHealthCheck extends HealthCheck {
     @Override
     protected Result check() {
         List<String> trustAnchorEntityIds = metadataResolverRepository.getTrustAnchorsEntityIds();
-        if (trustAnchorEntityIds.isEmpty()){
-            return Result.unhealthy("No trust anchors found");
-        }
 
-        List<String> errors = new ArrayList<>();
-        errors.addAll(getErrorsCreatingMetadataResolvers(trustAnchorEntityIds));
-        errors.addAll(getErrorsResolvingMetadata());
+        List<String> missingEntityIds = getErrorsCreatingMetadataResolvers(trustAnchorEntityIds);
+        Map<String, String> unresolvedMetadata = getErrorsResolvingMetadata();
 
-        if (errors.isEmpty()) {
+        if (missingEntityIds.isEmpty() && unresolvedMetadata.isEmpty()) {
             return Result.healthy();
         }
-        return Result.unhealthy(String.join(". ", errors));
+        return Result.builder().unhealthy()
+                .withDetail("missingMetadataResolverEntityIds", missingEntityIds)
+                .withDetail("unresolvedMetadata", unresolvedMetadata)
+                .build();
     }
 
     private List<String> getErrorsCreatingMetadataResolvers(List<String> trustAnchorEntityIds) {
@@ -46,23 +46,23 @@ public class EidasTrustAnchorHealthCheck extends HealthCheck {
             List<String> missingMetadataResolverEntityIds = new ArrayList<>(trustAnchorEntityIds);
             missingMetadataResolverEntityIds.removeAll(entityIdsWithResolver);
 
-            return Collections.singletonList("Metadata Resolver(s) not created for: " + String.join(", ", missingMetadataResolverEntityIds));
+            return missingMetadataResolverEntityIds;
         }
         return Collections.emptyList();
     }
 
-    private List<String> getErrorsResolvingMetadata() {
+    private Map<String, String> getErrorsResolvingMetadata() {
         Map<String, MetadataResolver> metadataResolvers = metadataResolverRepository.getMetadataResolvers();
-        List<String> errors = new ArrayList<>();
+        Map<String, String> errors = new HashMap<>();
         metadataResolvers.forEach((entityId, metadataResolver) -> {
             try {
                 CriteriaSet criteria = new CriteriaSet(new EntityIdCriterion(entityId));
                 EntityDescriptor entityDescriptor = metadataResolver.resolveSingle(criteria);
                 if (entityDescriptor == null){
-                    errors.add("Could not resolve metadata for " + entityId);
+                    errors.put(entityId, "Could not resolve metadata");
                 }
             } catch (ResolverException e) {
-                errors.add(String.format("Exception thrown resolving metadata for %s - %s ", entityId, e.getMessage()));
+                errors.put(entityId, e.getMessage());
             }
         });
         return errors;

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
@@ -16,6 +16,7 @@ import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,10 +38,10 @@ public class EidasTrustAnchorHealthCheckTest {
     }
 
     @Test
-    public void shouldReturnUnhealthyWhenNoTrustAnchorsAreFound() {
+    public void shouldReturnHealthyWhenNoTrustAnchorsAreFound() {
         Result result = eidasTrustAnchorHealthCheck.check();
 
-        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.isHealthy()).isTrue();
     }
 
     @Test
@@ -67,8 +68,8 @@ public class EidasTrustAnchorHealthCheckTest {
         Result result = eidasTrustAnchorHealthCheck.check();
 
         assertThat(result.isHealthy()).isFalse();
-        assertThat(result.getMessage()).contains(entityId2, entityId3);
-        assertThat(result.getMessage()).doesNotContain(entityId1);
+        assertThat(((Map<String, String>)result.getDetails().get("unresolvedMetadata")).keySet()).contains(entityId2, entityId3);
+        assertThat(((Map<String, String>)result.getDetails().get("unresolvedMetadata")).keySet()).doesNotContain(entityId1);
     }
 
     @Test
@@ -89,8 +90,8 @@ public class EidasTrustAnchorHealthCheckTest {
         Result result = eidasTrustAnchorHealthCheck.check();
 
         assertThat(result.isHealthy()).isFalse();
-        assertThat(result.getMessage()).contains(entityId2, entityId3);
-        assertThat(result.getMessage()).doesNotContain(entityId1);
+        assertThat((List<String>)result.getDetails().get("missingMetadataResolverEntityIds")).contains(entityId2, entityId3);
+        assertThat((List<String>)result.getDetails().get("missingMetadataResolverEntityIds")).doesNotContain(entityId1);
     }
 
     @Test


### PR DESCRIPTION
Healthcheck and unit tests now succeed when there are no trust anchors.
Changed healthcheck output to be more structured.
Returns details on each failure.

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>
Co-authored-by: dbes-gds <daniel.besbrode@digital.cabinet-office.gov.uk>