### PR TITLE
bau: upgrade to opensaml 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
             maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+            maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
             jcenter()
         }
         else {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ subprojects {
     apply plugin: 'maven-publish'
 
     ext {
-        opensaml_version = "3.3.0"
+        opensaml_version = "3.4.0"
         dropwizard_version = "1.3.5"
         ida_utils_version = '337'
         trust_anchor_version = '1.0-34'

--- a/saml-extensions/src/main/java/uk/gov/ida/saml/core/EidasSecurityConfigurationInitializer.java
+++ b/saml-extensions/src/main/java/uk/gov/ida/saml/core/EidasSecurityConfigurationInitializer.java
@@ -5,7 +5,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.opensaml.core.config.ConfigurationService;
 import org.opensaml.core.config.Initializer;
 import org.opensaml.xmlsec.SignatureValidationConfiguration;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.impl.BasicSignatureValidationConfiguration;
 
 import java.security.Security;

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/CredentialResolverFactory.java
@@ -4,7 +4,7 @@ import net.shibboleth.utilities.java.support.component.ComponentInitializationEx
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 
 public class CredentialResolverFactory {
     public MetadataCredentialResolver create(MetadataResolver metadataResolver) throws ComponentInitializationException {

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactory.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/factories/MetadataSignatureTrustEngineFactory.java
@@ -4,7 +4,7 @@ import net.shibboleth.utilities.java.support.component.ComponentInitializationEx
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 
 public class MetadataSignatureTrustEngineFactory {

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProviderTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProviderTest.java
@@ -28,7 +28,11 @@ import uk.gov.ida.saml.metadata.test.factories.metadata.TestCredentialFactory;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/saml-security/src/main/java/uk/gov/ida/saml/security/CredentialFactorySignatureValidator.java
+++ b/saml-security/src/main/java/uk/gov/ida/saml/security/CredentialFactorySignatureValidator.java
@@ -6,7 +6,7 @@ import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialResolver;
 import org.opensaml.security.credential.impl.StaticCredentialResolver;
 import org.opensaml.security.trust.TrustEngine;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolverTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedEncryptionCredentialResolverTest.java
@@ -11,7 +11,7 @@ import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.core.test.builders.metadata.EntitiesDescriptorBuilder;

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedSignatureValidatorTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/MetadataBackedSignatureValidatorTest.java
@@ -15,7 +15,7 @@ import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import org.opensaml.security.credential.Credential;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.X509Data;

--- a/saml-security/src/test/java/uk/gov/ida/saml/security/SignatureValidatorTest.java
+++ b/saml-security/src/test/java/uk/gov/ida/saml/security/SignatureValidatorTest.java
@@ -20,7 +20,7 @@ import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSAMD5;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA512;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureException;

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
@@ -3,11 +3,12 @@ package uk.gov.ida.saml.core.domain;
 import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 public class OutboundResponseFromHub extends IdaSamlResponse {
 
-    private Optional<String> matchingServiceAssertion;
+    private List<String> encryptedAssertions;
     private TransactionIdaStatus status;
 
     public OutboundResponseFromHub(
@@ -16,16 +17,16 @@ public class OutboundResponseFromHub extends IdaSamlResponse {
             String issuer,
             DateTime issueInstant,
             TransactionIdaStatus status,
-            Optional<String> matchingServiceAssertion,
+            List<String> encryptedAssertions,
             URI destination) {
 
         super(responseId, issueInstant, inResponseTo, issuer, destination);
-        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.encryptedAssertions = encryptedAssertions;
         this.status = status;
     }
 
-    public Optional<String> getMatchingServiceAssertion() {
-        return matchingServiceAssertion;
+    public List<String> getEncryptedAssertions() {
+        return encryptedAssertions;
     }
 
     public TransactionIdaStatus getStatus() {

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
@@ -10,6 +10,8 @@ import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import uk.gov.ida.saml.core.test.TestEntityIds;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.empty;
@@ -26,7 +28,7 @@ public class ResponseForHubBuilder {
     private Optional<Signature> signature = null;
     private Optional<PassthroughAssertion> authnStatementAssertion = empty();
     private Optional<PassthroughAssertion> matchingDatasetAssertion = empty();
-    private Optional<String> matchingServiceAssertion = empty();
+    private List<String> encryptedAssertions = Collections.emptyList();
 
 
     public static ResponseForHubBuilder anAuthnResponse() {
@@ -68,7 +70,7 @@ public class ResponseForHubBuilder {
                 TestEntityIds.HUB_ENTITY_ID,
                 issueInstant,
                 transactionIdpStatus,
-                matchingServiceAssertion,
+                encryptedAssertions,
                 URI.create("blah"));
     }
 
@@ -118,8 +120,8 @@ public class ResponseForHubBuilder {
         return this;
     }
 
-    public ResponseForHubBuilder withMatchingServiceAssertion(String matchingServiceAssertion) {
-        this.matchingServiceAssertion = ofNullable(matchingServiceAssertion);
+    public ResponseForHubBuilder withEncryptedAssertions(List<String> encryptedAssertions) {
+        this.encryptedAssertions = encryptedAssertions;
         return this;
     }
 }


### PR DESCRIPTION
Changes are:
- renaming of an imported classes package
- the PKIXSignatureValidationFilter now throws when it can't validate a signature (the exception is caught by the `MetadataResolver` so there's no noticable change to appication behaviour).