### PR TITLE
lKH7U7yW: handle an arbitrary number of assertions

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
@@ -3,11 +3,12 @@ package uk.gov.ida.saml.core.domain;
 import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 public class OutboundResponseFromHub extends IdaSamlResponse {
 
-    private Optional<String> matchingServiceAssertion;
+    private List<String> encryptedAssertions;
     private TransactionIdaStatus status;
 
     public OutboundResponseFromHub(
@@ -16,16 +17,16 @@ public class OutboundResponseFromHub extends IdaSamlResponse {
             String issuer,
             DateTime issueInstant,
             TransactionIdaStatus status,
-            Optional<String> matchingServiceAssertion,
+            List<String> encryptedAssertions,
             URI destination) {
 
         super(responseId, issueInstant, inResponseTo, issuer, destination);
-        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.encryptedAssertions = encryptedAssertions;
         this.status = status;
     }
 
-    public Optional<String> getMatchingServiceAssertion() {
-        return matchingServiceAssertion;
+    public List<String> getEncryptedAssertions() {
+        return encryptedAssertions;
     }
 
     public TransactionIdaStatus getStatus() {

--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
@@ -10,6 +10,8 @@ import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import uk.gov.ida.saml.core.test.TestEntityIds;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.empty;
@@ -26,7 +28,7 @@ public class ResponseForHubBuilder {
     private Optional<Signature> signature = null;
     private Optional<PassthroughAssertion> authnStatementAssertion = empty();
     private Optional<PassthroughAssertion> matchingDatasetAssertion = empty();
-    private Optional<String> matchingServiceAssertion = empty();
+    private List<String> encryptedAssertions = Collections.emptyList();
 
 
     public static ResponseForHubBuilder anAuthnResponse() {
@@ -68,7 +70,7 @@ public class ResponseForHubBuilder {
                 TestEntityIds.HUB_ENTITY_ID,
                 issueInstant,
                 transactionIdpStatus,
-                matchingServiceAssertion,
+                encryptedAssertions,
                 URI.create("blah"));
     }
 
@@ -118,8 +120,8 @@ public class ResponseForHubBuilder {
         return this;
     }
 
-    public ResponseForHubBuilder withMatchingServiceAssertion(String matchingServiceAssertion) {
-        this.matchingServiceAssertion = ofNullable(matchingServiceAssertion);
+    public ResponseForHubBuilder withEncryptedAssertions(List<String> encryptedAssertions) {
+        this.encryptedAssertions = encryptedAssertions;
         return this;
     }
 }


### PR DESCRIPTION
This will allow us to support the non-matching journey, where we will be sending out a response with the two assertions from the IDP, rather than a single assertion from the MDS.

https://trello.com/c/lKH7U7yW/185-wrap-assertions-in-hub-response-to-handle-idp-assertions

Solo: @alan-gds