### PR TITLE
BAU: Allow optional metadata bundling

### DIFF
--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/MetadataResolverCreationException.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/exception/MetadataResolverCreationException.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.metadata.exception;
+
+import java.net.URI;
+
+import static java.lang.String.format;
+
+public class MetadataResolverCreationException extends RuntimeException {
+    public MetadataResolverCreationException(URI metadataUri, String message) {
+        super(format("Failed to create metadata resolver for %s: %s", metadataUri, message));
+    }
+}

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataBundleTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataBundleTest.java
@@ -32,6 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -87,8 +88,8 @@ public class FederationMetadataBundleTest {
         @JsonProperty("metadata")
         private MultiTrustStoresBackedMetadataConfiguration metadataConfiguration;
 
-        public MetadataResolverConfiguration getMetadataConfiguration() {
-            return metadataConfiguration;
+        public Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+            return Optional.ofNullable(metadataConfiguration);
         }
     }
 

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataWithoutTrustStoresBundleTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataWithoutTrustStoresBundleTest.java
@@ -33,6 +33,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
+import java.util.Optional;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -79,8 +81,8 @@ public class FederationMetadataWithoutTrustStoresBundleTest {
         @JsonProperty("metadata")
         private TrustStoreBackedMetadataConfiguration metadataConfiguration;
 
-        public MetadataResolverConfiguration getMetadataConfiguration() {
-            return metadataConfiguration;
+        public Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+            return Optional.ofNullable(metadataConfiguration);
         }
     }
 


### PR DESCRIPTION
- We have multiple use cases where we might want to bind metadata or we
  might not (non-matching - MSA, eIDAS - enabled/disabled)
- By only creating the resolve and healthcheck if the configuration
  exists, we provide an easy way to "toggle" metadata
- Wrapped exceptions in new, more explicit exception but behaviour of "I
  fall over at startup" is the same as before

Co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>