### PR TITLE
EID-1072: Throw exception instead of error if expired cert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         opensaml_version = "3.4.0"
         dropwizard_version = "1.3.5"
         ida_utils_version = '337'
-        trust_anchor_version = '1.0-34'
+        trust_anchor_version = '1.0-51'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"
@@ -82,7 +82,7 @@ subprojects {
                 'org.assertj:assertj-joda-time:1.1.0',
                 'org.assertj:assertj-core:1.6.0',
                 'junit:junit:4.11',
-                'uk.gov.ida:ida-dev-pki:1.1.0-32',
+                'uk.gov.ida:ida-dev-pki:1.1.0-37',
                 'org.mockito:mockito-core:1.9.5'
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"

--- a/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
+++ b/saml-metadata-bindings/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
@@ -153,6 +153,7 @@ public class EidasMetadataResolverRepository implements MetadataResolverReposito
         Collection<String> errors = CountryTrustAnchor.findErrors(trustAnchor);
 
         if (!errors.isEmpty()) {
+            throwExceptionIfCertificateExpiredMessagePresent(errors);
             throw new Error(String.format("Managed to generate an invalid anchor: %s", String.join(", ", errors)));
         }
 
@@ -206,5 +207,12 @@ public class EidasMetadataResolverRepository implements MetadataResolverReposito
         private JerseyClientMetadataResolver getMetadataResolver() {
             return metadataResolver;
         }
+    }
+
+    private void throwExceptionIfCertificateExpiredMessagePresent(Collection<String> errors) throws CertificateException {
+        Optional<String> certExpiryErrorMessage = errors.stream()
+            .filter(message -> message.contains("X.509 certificate has expired"))
+            .findFirst();
+        if (certExpiryErrorMessage.isPresent()) throw new CertificateException(certExpiryErrorMessage.get());
     }
 }


### PR DESCRIPTION
The MSA won't start if the trust anchor has an expired cert in it. This
is because the `EidasMetadataResolverRepository` throws an `Error` if
it finds an expired cert. This brings the app down.

This updates so that an Exception is thrown instead which is cauht and
handled, whilst logging. Sensu will pick up any expired certs.