### PR TITLE
BAU Bump trust-anchor to 1.0-53

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         opensaml_version = "3.4.0"
         dropwizard_version = "1.3.5"
         ida_utils_version = '337'
-        trust_anchor_version = '1.0-51'
+        trust_anchor_version = '1.0-53'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"


### PR DESCRIPTION
The new version has mockito relocated to avoid version conflicts in
downstream packages.