### PR TITLE
BAU Bump trust anchor build to 56

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
         opensaml_version = "3.4.0"
         dropwizard_version = "1.3.5"
         ida_utils_version = '337'
-        trust_anchor_version = '1.0-53'
+        trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"


### PR DESCRIPTION
Build 56 relocates the assertj package in the shadowJar. It was causing
a clash when imported into the hub with hub's own dependency on assertj.