### PR TITLE
BAU: Update to use latest version of common-test-utils library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ subprojects {
 
     configurations {
         slf4j
+        jaxb
         guice
         opensaml
         dropwizard
@@ -55,6 +56,8 @@ subprojects {
 
     dependencies {
         slf4j 'org.slf4j:slf4j-api:1.7.21'
+
+        jaxb 'javax.xml.bind:jaxb-api:2.3.0'
 
         guice 'com.google.guava:guava:18.0',
                 'com.google.inject:guice:4.0'
@@ -75,15 +78,14 @@ subprojects {
                 "uk.gov.ida.eidas:trust-anchor:$trust_anchor_version",
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
-        test_deps "uk.gov.ida:common-test-utils:2.0.0-44",
+        test_deps "uk.gov.ida:common-test-utils:2.0.0-46",
                 "com.github.tomakehurst:wiremock-standalone:2.16.0",
                 "io.dropwizard:dropwizard-testing:$dropwizard_version",
                 'org.hamcrest:hamcrest-library:1.3',
                 'org.assertj:assertj-joda-time:1.1.0',
                 'org.assertj:assertj-core:1.6.0',
                 'junit:junit:4.11',
-                'uk.gov.ida:ida-dev-pki:1.1.0-37',
-                'org.mockito:mockito-core:1.9.5'
+                'uk.gov.ida:ida-dev-pki:1.1.0-37'
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"
     }

--- a/saml-extensions/src/main/java/uk/gov/ida/saml/core/test/OpenSAMLMockitoRunner.java
+++ b/saml-extensions/src/main/java/uk/gov/ida/saml/core/test/OpenSAMLMockitoRunner.java
@@ -1,7 +1,7 @@
 package uk.gov.ida.saml.core.test;
 
 import org.junit.runners.model.InitializationError;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 
 import java.lang.reflect.InvocationTargetException;

--- a/saml-metadata-bindings/build.gradle
+++ b/saml-metadata-bindings/build.gradle
@@ -3,7 +3,8 @@ dependencies {
     compile configurations.opensaml,
             configurations.dropwizard,
             configurations.guice,
-            configurations.security
+            configurations.security,
+            configurations.jaxb
 
     testCompile configurations.test_deps,
             project(':saml-metadata-bindings-test')

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import org.slf4j.LoggerFactory;
@@ -48,8 +48,8 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -103,7 +103,6 @@ public class EidasMetadataResolverRepositoryTest {
     public void setUp() throws CertificateException, SignatureException, ParseException, JOSEException, ComponentInitializationException {
         trustAnchors = new ArrayList<>();
         when(trustAnchorResolver.getTrustAnchors()).thenReturn(trustAnchors);
-        when(metadataClientFactory.getClient(eq(environment), any(), any())).thenReturn(metadataClient);
         when(dropwizardMetadataResolverFactory.createMetadataResolverWithClient(any(), eq(true), eq(metadataClient))).thenReturn(metadataResolver);
         when(metadataSignatureTrustEngineFactory.createSignatureTrustEngine(metadataResolver)).thenReturn(explicitKeySignatureTrustEngine);
     }
@@ -195,7 +194,6 @@ public class EidasMetadataResolverRepositoryTest {
         logger.addAppender(mockAppender);
         ArgumentCaptor<LoggingEvent> loggingEventCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
 
-        when(metadataConfiguration.getMetadataSourceUri()).thenReturn(UriBuilder.fromUri("https://source.com").build());
         String entityId = "http://signin.gov.uk/entity-id";
         List<String> certificateChain = asList(
             CACertificates.TEST_ROOT_CA,
@@ -222,7 +220,6 @@ public class EidasMetadataResolverRepositoryTest {
 
     @Test
     public void shouldNotCreateMetadataResolverRepositoryWhenCertificateIsInvalid() {
-        when(metadataConfiguration.getMetadataSourceUri()).thenReturn(UriBuilder.fromUri("https://source.com").build());
         String entityId = "http://signin.gov.uk/entity-id";
         List<String> invalidCertChain = asList(
                 CACertificates.TEST_ROOT_CA,

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorHealthCheckTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorResolverTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/EidasTrustAnchorResolverTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.shared.security.PrivateKeyFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.eidas.trustanchor.CountryTrustAnchor;

--- a/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/MetadataTrustStoreProviderTest.java
+++ b/saml-metadata-bindings/src/test/java/uk/gov/ida/saml/metadata/MetadataTrustStoreProviderTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.metadata.exception.EmptyTrustStoreException;
 import uk.gov.ida.saml.metadata.factories.MetadataTrustStoreProvider;

--- a/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
+++ b/saml-serializers/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
@@ -4,7 +4,7 @@ import org.apache.xml.security.utils.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 

--- a/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/ResponseSignatureCreatorTest.java
+++ b/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/ResponseSignatureCreatorTest.java
@@ -4,8 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.opensaml.saml.saml2.core.Issuer;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.xmlsec.signature.Signature;
 import uk.gov.ida.saml.security.SignatureFactory;
@@ -17,7 +16,12 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ResponseSignatureCreatorTest {
 
+    private static final String RESPONSE_ID = "response-id";
     private ResponseSignatureCreator responseSignatureCreator;
+
+    @Mock
+    private Response response;
+
     @Mock
     private SignatureFactory signatureFactory;
 
@@ -27,28 +31,19 @@ public class ResponseSignatureCreatorTest {
     }
 
     @Test
-    public void decorate_shouldGetSignatureAndAssignIt() {
-        Response response = mock(Response.class);
-        Issuer issuer = mock(Issuer.class);
-        String id = "response-id";
-        String issuerId = "some-issuer-id";
-        when(issuer.getValue()).thenReturn(issuerId);
-        when(response.getSignatureReferenceID()).thenReturn(id);
-        when(response.getIssuer()).thenReturn(issuer);
+    public void shouldGetSignatureAndAssignIt() {
+        when(response.getSignatureReferenceID()).thenReturn(RESPONSE_ID);
 
         responseSignatureCreator.addUnsignedSignatureTo(response);
 
-        verify(signatureFactory).createSignature(id);
+        verify(signatureFactory).createSignature(RESPONSE_ID);
     }
 
     @Test
-    public void decorate_shouldAssignSignatureToResponse() {
-        Response response = mock(Response.class);
+    public void shouldAssignSignatureToResponse() {
         Signature signature = mock(Signature.class);
-        String id = "response-id";
-        when(response.getIssuer()).thenReturn(mock(Issuer.class));
-        when(response.getSignatureReferenceID()).thenReturn(id);
-        when(signatureFactory.createSignature(id)).thenReturn(signature);
+        when(response.getSignatureReferenceID()).thenReturn(RESPONSE_ID);
+        when(signatureFactory.createSignature(RESPONSE_ID)).thenReturn(signature);
 
         responseSignatureCreator.addUnsignedSignatureTo(response);
 

--- a/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlResponseAssertionEncrypterTest.java
+++ b/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlResponseAssertionEncrypterTest.java
@@ -1,15 +1,16 @@
 package uk.gov.ida.saml.core.transformers.outbound.decorators;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.Mock;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Encrypter;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.encryption.support.EncryptionException;
-import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.security.EncrypterFactory;
 import uk.gov.ida.saml.security.EntityToEncryptForLocator;
 import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
@@ -26,67 +27,67 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(OpenSAMLRunner.class)
+@RunWith(OpenSAMLMockitoRunner.class)
 public class SamlResponseAssertionEncrypterTest {
+
+    private static final String REQUEST_ID = "request_id";
+    private static final String ENTITY_ID = "some id";
+    private static final String ENCRYPTION_EXCEPTION_MESSAGE = "BLAM!";
+
+    @Mock
+    private KeyStoreBackedEncryptionCredentialResolver credentialResolver;
+
+    @Mock
+    private EncrypterFactory encrypterFactory;
+
+    @Mock
+    private EntityToEncryptForLocator entityToEncryptForLocator;
+
+    @Mock
+    private Credential credential;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private Assertion assertion;
+
+    @Mock
+    private Encrypter encrypter;
+
+    private SamlResponseAssertionEncrypter assertionEncrypter;
+
+    @Before
+    public void setUp() {
+        when(response.getInResponseTo()).thenReturn(REQUEST_ID);
+        when(entityToEncryptForLocator.fromRequestId(REQUEST_ID)).thenReturn(ENTITY_ID);
+        when(credentialResolver.getEncryptingCredential(ENTITY_ID)).thenReturn(credential);
+        List<Assertion> assertionList = spy(newArrayList(assertion));
+        when(response.getAssertions()).thenReturn(assertionList);
+        when(encrypterFactory.createEncrypter(credential)).thenReturn(encrypter);
+        assertionEncrypter = new SamlResponseAssertionEncrypter(
+            credentialResolver,
+            encrypterFactory,
+            entityToEncryptForLocator
+        );
+    }
 
     @Test
     public void shouldConvertAssertionIntoEncryptedAssertion() throws EncryptionException {
-
-        KeyStoreBackedEncryptionCredentialResolver credentialFactory = mock(KeyStoreBackedEncryptionCredentialResolver.class);
-
-        Credential credential = mock(Credential.class);
-        EntityToEncryptForLocator entityToEncryptForLocator = mock(EntityToEncryptForLocator.class);
-        when(entityToEncryptForLocator.fromRequestId(Matchers.anyString())).thenReturn("some id");
-        when(credentialFactory.getEncryptingCredential("some id")).thenReturn(credential);
-
-
-        EncrypterFactory encrypterFactory = mock(EncrypterFactory.class);
-        Encrypter encrypter = mock(Encrypter.class);
-        when(encrypterFactory.createEncrypter(credential)).thenReturn(encrypter);
-
-
-        Response response = mock(Response.class);
-        Assertion assertion = mock(Assertion.class);
-        List<Assertion> assertionList = spy(newArrayList(assertion));
-        when(response.getAssertions()).thenReturn(assertionList);
-
         EncryptedAssertion encryptedAssertion = mock(EncryptedAssertion.class);
         when(encrypter.encrypt(assertion)).thenReturn(encryptedAssertion);
-        List<EncryptedAssertion> encryptedAssertionList = spy(new ArrayList<EncryptedAssertion>());
+        List<EncryptedAssertion> encryptedAssertionList = spy(new ArrayList<>());
         when(response.getEncryptedAssertions()).thenReturn(encryptedAssertionList);
 
-        SamlResponseAssertionEncrypter assertionEncrypter = new SamlResponseAssertionEncrypter(credentialFactory, encrypterFactory,
-                entityToEncryptForLocator
-        );
-
         assertionEncrypter.encryptAssertions(response);
+
         verify(encryptedAssertionList, times(1)).add(encryptedAssertion);
     }
 
     @Test
     public void decorate_shouldWrapEncryptionAssertionInSamlExceptionWhenEncryptionFails() throws EncryptionException {
-        KeyStoreBackedEncryptionCredentialResolver credentialFactory = mock(KeyStoreBackedEncryptionCredentialResolver.class);
-
-        Credential credential = mock(Credential.class);
-        EntityToEncryptForLocator entityToEncryptForLocator = mock(EntityToEncryptForLocator.class);
-        when(entityToEncryptForLocator.fromRequestId(Matchers.anyString())).thenReturn("some id");
-        when(credentialFactory.getEncryptingCredential("some id")).thenReturn(credential);
-
-        Response response = mock(Response.class);
-        Assertion assertion = mock(Assertion.class);
-        List<Assertion> assertionList = spy(newArrayList(assertion));
-        when(response.getAssertions()).thenReturn(assertionList);
-
-        EncrypterFactory encrypterFactory = mock(EncrypterFactory.class);
-        Encrypter encrypter = mock(Encrypter.class);
-        when(encrypterFactory.createEncrypter(credential)).thenReturn(encrypter);
-        EncryptionException encryptionException = new EncryptionException("BLAM!");
+        EncryptionException encryptionException = new EncryptionException(ENCRYPTION_EXCEPTION_MESSAGE);
         when(encrypter.encrypt(assertion)).thenThrow(encryptionException);
-
-        SamlResponseAssertionEncrypter assertionEncrypter =
-                new SamlResponseAssertionEncrypter(credentialFactory, encrypterFactory,
-                        entityToEncryptForLocator
-                );
 
         try {
             assertionEncrypter.encryptAssertions(response);

--- a/saml-utils/src/test/java/uk/gov/ida/saml/hub/validators/StringSizeValidatorTest.java
+++ b/saml-utils/src/test/java/uk/gov/ida/saml/hub/validators/StringSizeValidatorTest.java
@@ -2,7 +2,7 @@ package uk.gov.ida.saml.hub.validators;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
 import uk.gov.ida.saml.hub.errors.SamlTransformationErrorFactory;
 


### PR DESCRIPTION
This pull request contains the following changes. 

* common-test-utils library is using latest version of mockito-core and is compatible with Java 11.
* Remove org.mockito:mockito-core:1.9.5 as this library is too old.
* Update all unit tests to use org.mockito.junit.MockitoJUnitRunner instead of org.mockito.runners.MockitoJUnitRunner since org.mockito.runners.MockitoJUnitRunner is deprecated.
* Replace org.mockito.Matchers.* with org.mockito.ArgumentMatchers.* since org.mockito.Matchers.* is deprecated.
* Resolve UnnecessaryStubbingException in unit tests.
* Refactor ResponseSignatureCreatorTest to get rid of duplicate code and NullPointerException and make it easy to read.
* Add jaxb library to resolve NoClassDefFoundError raised in EidasTrustAnchorResolverTest.

These changes are needed because verify-hub has two versions of mockito-core (1.9.6) and (2.23.0) libraries loaded. The old version of mockito-core uses ArgumentMatcher (Abstract class) whereas the new version of mockito-core uses ArgumentMatcher (Interface class). This causes Integrated Development Environment (IDE) to be confused and to throw an error message not letting me to compile in IDE. James made changes to verify-test-utils (https://github.com/alphagov/verify-test-utils/commit/a47f74a316fd744d1f0e9fa01c64b95b9551c2ce) to use latest version of mockito-core (2.23.0) so that it is compatible with Java 11. Unfortunately, verify-hub is still using old version of verify-test-utils library due to verify-saml-libs' dependencies. This change should fix this issue.

Author: @adityapahuja