### PR TITLE
Remove circular dependancy on trust anchor, and bump security utils.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     ext {
         opensaml_version = "3.4.0"
         dropwizard_version = "1.3.5"
-        ida_utils_version = '337'
+        ida_utils_version = '348'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
@@ -75,7 +75,6 @@ subprojects {
                 'net.shibboleth.utilities:java-support:7.2.0'
 
         security 'com.nimbusds:nimbus-jose-jwt:5.4',
-                "uk.gov.ida.eidas:trust-anchor:$trust_anchor_version",
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
         test_deps "uk.gov.ida:common-test-utils:2.0.0-46",


### PR DESCRIPTION
The new version of the security utils bump has the extra SLF4J removed.