### PR TITLE
EID-1293 - Create HashFactory to hash certain attributes of the response

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/ResponseAttributesHashFactory.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/ResponseAttributesHashFactory.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.saml.core.transformers;
+
+import org.apache.commons.codec.binary.Hex;
+import org.opensaml.security.crypto.JCAConstants;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.MessageFormat;
+import java.util.regex.Pattern;
+
+public class ResponseAttributesHashFactory {
+
+    private ResponseAttributesHashFactory() {
+    }
+
+    public static String hashResponseDetails(String pid, String firstName, String middlename, String lastName, String dateOfBirth) {
+
+        Pattern dateFormat = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+        if (!dateFormat.matcher(dateOfBirth).matches()) {
+            throw new RuntimeException("Date does not match format YYYY-MM-DD");
+        }
+
+        MessageDigest messageDigest;
+
+        try {
+            messageDigest = MessageDigest.getInstance(JCAConstants.DIGEST_SHA256);
+
+            String toHash = MessageFormat.format("{0},{1},{2},{3},{4}",
+                    pid, firstName, middlename, lastName, dateOfBirth);
+
+            messageDigest.update(toHash.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        byte[] digest = messageDigest.digest();
+
+        return Hex.encodeHexString(digest);
+    }
+}

--- a/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/ResponseAttributesHashFactoryTest.java
+++ b/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/ResponseAttributesHashFactoryTest.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.transformers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static uk.gov.ida.saml.core.transformers.ResponseAttributesHashFactory.hashResponseDetails;
+
+public class ResponseAttributesHashFactoryTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldCreateHashOfResponseAttributes() {
+        String hashedResponse = hashResponseDetails("pid", "jim", "bob", "joe", "1989-10-10");
+
+        assertEquals("Hashes do not match up", hashedResponse, "437256f80cf561b2fa195bd1ed4293d4432d1c83090558bf3dd568c272943fd8");
+    }
+
+    @Test
+    public void shouldThrowWhenDateFormatIsIncorrect() {
+        exception.expect(RuntimeException.class);
+        exception.expectMessage("Date does not match format YYYY-MM-DD");
+
+        hashResponseDetails("pid", "jim", "bob", "joe", "10-10-1989");
+    }
+}


### PR DESCRIPTION
- This HashFactory will be used in 2 scenarios 
 Hub - To Hash the attributes of responses that are going back to the proxy node
 Proxy Node - To Hash the attributes of the response from the Hub
- Check the Date format matches YYYY-MM-DD and throw if not 