### PR TITLE
Only clear out MDC properties set by this logger

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLogger.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLogger.java
@@ -25,6 +25,9 @@ import java.util.List;
 
 public final class EidasResponseAttributesHashLogger {
 
+    public static final String MDC_KEY_EIDAS_REQUEST_ID = "eidasRequestId";
+    public static final String MDC_KEY_EIDAS_DESTINATION = "eidasDestination";
+    public static final String MDC_KEY_EIDAS_USER_HASH = "eidasUserHash";
     private Logger log = LoggerFactory.getLogger(EidasResponseAttributesHashLogger.class);
 
     private transient final ResponseAttributes responseAttributes;
@@ -63,12 +66,14 @@ public final class EidasResponseAttributesHashLogger {
 
     public void logHashFor(String requestId, String destination) {
         try {
-            MDC.put("eidasRequestId", requestId);
-            MDC.put("eidasDestination", destination);
-            MDC.put("eidasUserHash", buildHash());
+            MDC.put(MDC_KEY_EIDAS_REQUEST_ID, requestId);
+            MDC.put(MDC_KEY_EIDAS_DESTINATION, destination);
+            MDC.put(MDC_KEY_EIDAS_USER_HASH, buildHash());
             log.info("Hash of eIDAS user attributes");
         } finally {
-            MDC.clear();
+            MDC.remove(MDC_KEY_EIDAS_REQUEST_ID);
+            MDC.remove(MDC_KEY_EIDAS_DESTINATION);
+            MDC.remove(MDC_KEY_EIDAS_USER_HASH);
         }
     }
 

--- a/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLoggerTest.java
+++ b/saml-utils/src/test/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLoggerTest.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_DESTINATION;
+import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_REQUEST_ID;
+import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_USER_HASH;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EidasResponseAttributesHashLoggerTest {
@@ -139,9 +142,9 @@ public class EidasResponseAttributesHashLoggerTest {
         assertThat(loggingEvent.getLevel()).isEqualTo(Level.INFO);
         assertThat(loggingEvent.getMessage()).doesNotContain("a request id", "a destination", hash);
         Map<String, String> mdcPropertyMap = loggingEvent.getMDCPropertyMap();
-        assertThat(mdcPropertyMap.get("eidasRequestId")).isEqualTo("a request id");
-        assertThat(mdcPropertyMap.get("eidasDestination")).isEqualTo("a destination");
-        assertThat(mdcPropertyMap.get("eidasUserHash")).isEqualTo(hash);
+        assertThat(mdcPropertyMap.get(MDC_KEY_EIDAS_REQUEST_ID)).isEqualTo("a request id");
+        assertThat(mdcPropertyMap.get(MDC_KEY_EIDAS_DESTINATION)).isEqualTo("a destination");
+        assertThat(mdcPropertyMap.get(MDC_KEY_EIDAS_USER_HASH)).isEqualTo(hash);
     }
 
     @Test


### PR DESCRIPTION
We should not clear out the entire MDC map for the current thread when we are finished logging our event.