### PR TITLE
BAU Bump dropwizard_version to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     ext {
         opensaml_version = "3.4.0"
-        dropwizard_version = "1.3.5"
+        dropwizard_version = "1.3.9"
         ida_utils_version = '348'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"


### PR DESCRIPTION
Version 1.3.5 was vulnerable to a range of CVEs. Bumping to 1.3.9
alleviates this.