### PR TITLE
Renamed some MDC keys used for logging eIDAS user attributes hash

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLogger.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/transformers/EidasResponseAttributesHashLogger.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 public final class EidasResponseAttributesHashLogger {
 
-    public static final String MDC_KEY_EIDAS_REQUEST_ID = "eidasRequestId";
-    public static final String MDC_KEY_EIDAS_DESTINATION = "eidasDestination";
+    public static final String MDC_KEY_EIDAS_REQUEST_ID = "hubRequestId";
+    public static final String MDC_KEY_EIDAS_DESTINATION = "destination";
     public static final String MDC_KEY_EIDAS_USER_HASH = "eidasUserHash";
     private Logger log = LoggerFactory.getLogger(EidasResponseAttributesHashLogger.class);
 


### PR DESCRIPTION
After a review of user has logs with cyber, we agreed to change the names of MDC keys to:
eidasRequestId -> hubRequestId
eidasDestination -> destination