### PR TITLE
BAU Downgrade dropwizard to 1.3.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     ext {
         opensaml_version = "3.4.0"
-        dropwizard_version = "1.3.9"
+        dropwizard_version = "1.3.8"
         ida_utils_version = '348'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"


### PR DESCRIPTION
Build 179 bumped the version to 1.3.9. This caused an issue in the hub
with a bunch of integration tests which are hard to debug.

For the sake of progress with the proxy-node (which needs the hub to use
a build of saml-libs greater than 179) we're downgrading until we can
work out what's up with 1.3.9.