### PR TITLE
EIDAS: Copy VSP UserIdHashFactory

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/hub/factories/UserIdHashFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/hub/factories/UserIdHashFactory.java
@@ -1,0 +1,61 @@
+package uk.gov.ida.saml.hub.factories;
+
+import org.apache.commons.codec.binary.Hex;
+import org.opensaml.security.crypto.JCAConstants;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.MessageFormat;
+import java.util.Optional;
+
+
+public class UserIdHashFactory {
+    private final String hashingEntityId;
+
+    public UserIdHashFactory(String hashingEntityId) {
+        this.hashingEntityId = hashingEntityId;
+    }
+
+    public String hashId(String issuerEntityId, String persistentId, Optional<AuthnContext> authnContext) {
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance(JCAConstants.DIGEST_SHA256);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        final String toHash = idToHash(issuerEntityId, persistentId, authnContext);
+
+        try {
+            messageDigest.update(toHash.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+
+        byte[] digest = messageDigest.digest();
+        return Hex.encodeHexString(digest);
+    }
+
+    private String idToHash(String issuerEntityId, String persistentId, Optional<AuthnContext> context) {
+        String persistentIdHash;
+
+        final AuthnContext authnContext = context.orElseThrow(() -> new AuthnContextMissingException(String.format("Authn context absent for persistent id %s", persistentId)));
+        if (authnContext.equals(AuthnContext.LEVEL_2)) {
+            // default behaviour - for LEVEL_2
+            persistentIdHash = MessageFormat.format("{0}{1}{2}", issuerEntityId, hashingEntityId, persistentId);
+        } else {
+            // if we have an authnContext that is not LEVEL_2 then regenerate the hash
+            // this does not break existing behaviour for LEVEL_2 RPs
+            persistentIdHash = MessageFormat.format("{0}{1}{2}{3}", issuerEntityId, hashingEntityId, persistentId, authnContext.name());
+        }
+        return persistentIdHash;
+    }
+
+    class AuthnContextMissingException extends RuntimeException {
+      AuthnContextMissingException(String message) {
+        super(message);
+      }
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/hub/factories/UserIdHashFactoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/hub/factories/UserIdHashFactoryTest.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.saml.hub.factories;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistentId;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserIdHashFactoryTest {
+
+    private static final String HASHING_ENTITY_ID = "entity";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private UserIdHashFactory userIdHashFactory = new UserIdHashFactory(HASHING_ENTITY_ID);
+
+    @Test
+    public void shouldPerformHashing() {
+        final PersistentId persistentId = aPersistentId().build();
+        final String issuerId = "partner";
+
+        final String hashedId = userIdHashFactory.hashId(issuerId, persistentId.getNameId(), Optional.of(AuthnContext.LEVEL_2));
+
+        assertThat(hashedId).isEqualTo("a5fbea969c3837a712cbe9e188804796828f369106478e623a436fa07e8fd298");
+    }
+
+    @Test
+    public void shouldGenerateADifferentHashForEveryLevelOfAssurance(){
+        final PersistentId persistentId = aPersistentId().build();
+        final String partnerEntityId = "partner";
+
+        final long numberOfUniqueGeneratedHashedPids = Arrays.stream(AuthnContext.values())
+                .map(authnContext -> userIdHashFactory.hashId(partnerEntityId, persistentId.getNameId(), Optional.of(authnContext)))
+                .distinct()
+                .count();
+
+        assertThat(numberOfUniqueGeneratedHashedPids).isEqualTo(5);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenAuthnContextAbsent() {
+        exception.expect(UserIdHashFactory.AuthnContextMissingException.class);
+        exception.expectMessage(String.format("Authn context absent for persistent id %s", "pid"));
+
+        userIdHashFactory.hashId("", "pid", Optional.empty());
+    }
+}


### PR DESCRIPTION
We need to hash the user's PID in saml-engine in the same way as we do
in the VSP for security logging purposes.