### PR TITLE
BAU Bump dropwizard to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     ext {
         opensaml_version = "3.4.2"
-        dropwizard_version = "1.3.8"
+        dropwizard_version = "1.3.9"
         ida_utils_version = '348'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"


### PR DESCRIPTION
This has been prompted by a snyk alert in the proxy-node for a medium
risk vulnerability being brought in by the saml-lib package. It's a DoS
vulnerability in Jetty but is fixed by this bump.

This also brings the version inline with hub and proxy-node.