### PR TITLE
bau - move msa SAML classes out of hub-saml

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/IdaMatchingServiceResponse.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/IdaMatchingServiceResponse.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public abstract class IdaMatchingServiceResponse extends IdaMessage implements IdaResponse {
+
+    private String inResponseTo;
+
+    protected IdaMatchingServiceResponse() {
+    }
+
+    public IdaMatchingServiceResponse(String responseId, String inResponseTo, String issuer, DateTime issueInstant) {
+        super(responseId, issuer, issueInstant);
+        this.inResponseTo = inResponseTo;
+    }
+
+    public String getInResponseTo() {
+        return inResponseTo;
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceAuthnStatement.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceAuthnStatement.java
@@ -1,0 +1,23 @@
+package uk.gov.ida.saml.core.domain;
+
+public final class MatchingServiceAuthnStatement {
+
+    private AuthnContext authnContext;
+
+    private MatchingServiceAuthnStatement() {
+    }
+
+    private MatchingServiceAuthnStatement(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+    }
+
+    public AuthnContext getAuthnContext() {
+        return authnContext;
+    }
+
+    public static MatchingServiceAuthnStatement createIdaAuthnStatement(
+            AuthnContext authnContext) {
+
+        return new MatchingServiceAuthnStatement(authnContext);
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/SamlAttributeQueryAssertionEncrypter.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/domain/SamlAttributeQueryAssertionEncrypter.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.AbstractAssertionEncrypter;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
+
+import java.util.List;
+
+public class SamlAttributeQueryAssertionEncrypter extends AbstractAssertionEncrypter<AttributeQuery> {
+
+    @Inject
+    public SamlAttributeQueryAssertionEncrypter(
+            final KeyStoreBackedEncryptionCredentialResolver credentialResolver,
+            final EncrypterFactory encrypterFactory,
+            final EntityToEncryptForLocator entityToEncryptForLocator) {
+
+        super(encrypterFactory, entityToEncryptForLocator, credentialResolver);
+    }
+
+    @Override
+    protected String getRequestId(final AttributeQuery attributeQuery) {
+        return attributeQuery.getID();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected List<EncryptedAssertion> getEncryptedAssertions(final AttributeQuery attributeQuery) {
+        final SubjectConfirmationData subjectConfirmationData = attributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+
+        return (List<EncryptedAssertion>) (List<?>)
+                subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected List<Assertion> getAssertions(final AttributeQuery attributeQuery) {
+        final SubjectConfirmationData subjectConfirmationData = attributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+        return (List<Assertion>) (List<?>)
+                subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionAttributeStatementValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionAttributeStatementValidator.java
@@ -1,0 +1,72 @@
+package uk.gov.ida.saml.core.validation.assertion;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidAttributeLanguageInAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidFraudAttribute;
+
+public class AssertionAttributeStatementValidator {
+
+    public static final String INVALID_FRAUD_EVENT_TYPE = "Invalid fraud event type";
+    private static final String INVALID_FRAUD_EVENT_NAME = "Invalid fraud event name";
+    private static final String INVALID_NUMBER_OF_FRAUD_EVENT_ATTRIBUTE_STATEMENTS = "Invalid number of fraud event attribute statements";
+
+    public void validate(Assertion assertion) {
+        for (AttributeStatement attributeStatement : assertion.getAttributeStatements()) {
+            for (Attribute attribute : attributeStatement.getAttributes()) {
+                for (XMLObject attributeValue : attribute.getAttributeValues()) {
+                    if (attributeValue instanceof PersonName) {
+                        PersonName personName = (PersonName) attributeValue;
+                        String language = personName.getLanguage();
+                        if (language != null && !IdaConstants.IDA_LANGUAGE.equals(language)) {
+                            SamlValidationSpecificationFailure failure = invalidAttributeLanguageInAssertion(attribute.getName(), language);
+                            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void validateFraudEvent(Assertion assertion) {
+        if(assertion.getAttributeStatements().size() != 1){
+            SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_NUMBER_OF_FRAUD_EVENT_ATTRIBUTE_STATEMENTS);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        else {
+            AttributeStatement attributeStatement = assertion.getAttributeStatements().get(0);
+            validateFraudEvent(attributeStatement);
+        }
+    }
+
+    private void validateFraudEvent(AttributeStatement attributeStatement) {
+        Attribute fraudEventAttribute = Iterables.find(attributeStatement.getAttributes(), new Predicate<Attribute>() {
+            @Override
+            public boolean apply(Attribute input) {
+                return input.getName().equals(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+            }
+        }, null);
+        if(fraudEventAttribute == null){
+            SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_FRAUD_EVENT_NAME);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        } else {
+            boolean didNotDeserializeCorrectlyIntoFraudEventType = !(fraudEventAttribute.getAttributeValues().get(0) instanceof IdpFraudEventId);
+            if (didNotDeserializeCorrectlyIntoFraudEventType) {
+                SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_FRAUD_EVENT_TYPE);
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+            }
+        }
+    }
+
+
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -1,0 +1,78 @@
+package uk.gov.ida.saml.core.validation.assertion;
+
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.validation.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil;
+
+public class AssertionValidator {
+
+    private final IssuerValidator issuerValidator;
+    private final AssertionSubjectValidator subjectValidator;
+    protected final AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+    private final BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator;
+
+    public AssertionValidator(
+            IssuerValidator issuerValidator,
+            AssertionSubjectValidator subjectValidator,
+            AssertionAttributeStatementValidator assertionAttributeStatementValidator,
+            BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator) {
+
+        this.issuerValidator = issuerValidator;
+        this.subjectValidator = subjectValidator;
+        this.assertionAttributeStatementValidator = assertionAttributeStatementValidator;
+        this.basicAssertionSubjectConfirmationValidator = basicAssertionSubjectConfirmationValidator;
+    }
+
+    public void validate(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        Signature signature = assertion.getSignature();
+        if (assertion.getID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (signature == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSignatureMissing(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (assertion.getIssueInstant() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingIssueInstant(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (assertion.getVersion() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingVersion(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalVersion(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        issuerValidator.validate(assertion.getIssuer());
+        assertionAttributeStatementValidator.validate(assertion);
+
+        validateSubject(assertion, requestId, expectedRecipientId);
+        basicAssertionSubjectConfirmationValidator.validate(assertion.getSubject().getSubjectConfirmations().get(0));
+    }
+
+    protected void validateSubject(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        subjectValidator.validate(assertion.getSubject(), assertion.getID());
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/IdentityProviderAssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/IdentityProviderAssertionValidator.java
@@ -1,0 +1,117 @@
+package uk.gov.ida.saml.core.validation.assertion;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.validation.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IdentityProviderAssertionValidator extends AssertionValidator {
+
+    private final AssertionSubjectConfirmationValidator subjectConfirmationValidator;
+
+    public IdentityProviderAssertionValidator(
+            IssuerValidator issuerValidator,
+            AssertionSubjectValidator subjectValidator,
+            AssertionAttributeStatementValidator assertionAttributeStatementValidator,
+            AssertionSubjectConfirmationValidator subjectConfirmationValidator) {
+
+        super(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+
+        this.subjectConfirmationValidator = subjectConfirmationValidator;
+    }
+
+    public void validateConsistency(Assertion authnStatementAssertion, Assertion matchingDatasetAssertion) {
+        validateConsistency(Arrays.asList(authnStatementAssertion, matchingDatasetAssertion));
+    }
+
+    public void validateConsistency(List<Assertion> assertions) {
+        ensurePidsMatch(assertions);
+
+        ensureIssuersMatch(assertions);
+    }
+
+    private void ensurePidsMatch(List<Assertion> assertions) {
+        boolean pidsDoNotMatch = assertions.stream()
+            .map(assertion -> assertion.getSubject().getNameID().getValue())
+            .distinct()
+            .count() > 1;
+
+        if (pidsDoNotMatch) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.mismatchedPersistentIdentifiers();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void ensureIssuersMatch(List<Assertion> assertions) {
+        boolean issuerValuesDoNotMatch = assertions.stream()
+            .map(assertion -> assertion.getIssuer().getValue())
+            .distinct()
+            .count() > 1;
+
+        if (issuerValuesDoNotMatch) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.mismatchedIssuers();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    @Override
+    public void validateSubject(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        super.validateSubject(assertion, requestId, expectedRecipientId);
+
+        ensurePresenceOfBearerSubjectConfirmation(assertion);
+
+        validateAllBearerSubjectConfirmations(assertion, requestId, expectedRecipientId);
+
+        validateFraudAttribute(assertion);
+    }
+
+    private void validateAllBearerSubjectConfirmations(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        for (SubjectConfirmation subjectConfirmation : assertion.getSubject().getSubjectConfirmations()) {
+            if (SubjectConfirmation.METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
+                subjectConfirmationValidator.validate(subjectConfirmation, requestId, expectedRecipientId);
+            }
+        }
+    }
+
+    private void ensurePresenceOfBearerSubjectConfirmation(Assertion assertion) {
+        boolean hasSubjectConfirmationWithBearerMethod = false;
+        for (SubjectConfirmation subjectConfirmation : assertion.getSubject().getSubjectConfirmations()) {
+            if (SubjectConfirmation.METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
+                hasSubjectConfirmationWithBearerMethod = true;
+            }
+        }
+
+        if (!hasSubjectConfirmationWithBearerMethod) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.noSubjectConfirmationWithBearerMethod(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateFraudAttribute(Assertion assertion) {
+        if (assertion.getAuthnStatements().size() == 1){
+            AuthnStatement authnStatement = assertion.getAuthnStatements().get(0);
+            boolean isFraudResponse = authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef().equals(AuthnContext.LEVEL_X.getUri());
+            if (isFraudResponse)
+            {
+                assertionAttributeStatementValidator.validateFraudEvent(assertion);
+            }
+        }
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
@@ -1,0 +1,376 @@
+package uk.gov.ida.saml.core.errors;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationWarning;
+import uk.gov.ida.saml.core.validation.errors.AuthnContextMissingError;
+import uk.gov.ida.saml.core.validation.errors.AuthnRequestFromTransactionValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.BearerSubjectConfirmationValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.DuplicateRequestIdValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.errors.GenericHubProfileValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.InvalidAttributeLanguageInAssertion;
+import uk.gov.ida.saml.core.validation.errors.InvalidAttributeNameFormat;
+import uk.gov.ida.saml.core.validation.errors.RelayStateValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.RequestFreshnessValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification;
+import uk.gov.ida.saml.core.validation.errors.SamlValidationSpecification;
+
+import javax.xml.namespace.QName;
+import java.net.URI;
+
+import static java.lang.String.format;
+import static uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification.ATTRIBUTE_STATEMENT_EMPTY;
+
+public final class SamlTransformationErrorFactory {
+
+    private SamlTransformationErrorFactory() {
+    }
+
+    public static SamlValidationSpecificationFailure duplicateRequestId(String requestId, String issuerId) {
+        return new DuplicateRequestIdValidationSpecificationFailure(DuplicateRequestIdValidationSpecificationFailure.DUPLICATE_REQUEST_ID, requestId, issuerId);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextMissingError() {
+        return new AuthnContextMissingError(AuthnContextMissingError.MISSING_AUTHN_CONTEXT, false);
+    }
+
+    public static SamlValidationSpecificationFailure scopingNotAllowed() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.SCOPE_NOT_ALLOWED);
+    }
+
+    public static SamlValidationSpecificationFailure illegalProtocolBindingError(final String protocolBinding, final String expectedProtocolBinding) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.PROTOCOL_BINDING, protocolBinding, expectedProtocolBinding);
+    }
+
+    public static SamlValidationSpecificationFailure unrecognisedBinding(final String binding) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.UNRECOGNISED_BINDING, binding);
+    }
+
+    public static SamlValidationSpecificationFailure isPassiveNotAllowed() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.PASSIVE_NOT_ALLOWED);
+    }
+
+    public static SamlValidationSpecificationFailure missingNameIDPolicy() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_NAME_ID_POLICY);
+    }
+
+    public static SamlValidationSpecificationFailure illegalNameIDPolicy(final String policy) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.ILLEGAL_NAME_ID_POLICY, policy);
+    }
+
+    public static SamlValidationSpecificationFailure attributeStatementEmpty(final String assertionId) {
+        return new ResponseProcessingValidationSpecification(ATTRIBUTE_STATEMENT_EMPTY, assertionId);
+    }
+
+    public static SamlValidationSpecificationFailure missingInResponseTo() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_INRESPONSE_TO);
+    }
+
+    public static SamlValidationSpecificationFailure emptyInResponseTo() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.EMPTY_INRESPONSE_TO);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextClassRefMissing() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_CONTEXT_CLASS_REF, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextClassRefValueMissing() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_CONTEXT_CLASS_REF_VALUE, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnInstantMissing() {
+        return new ResponseProcessingValidationSpecification("AuthnStatement is missing 'AuthnInstant'"); //TODO: need to update saml-extensions to constantise this string
+    }
+
+    public static SamlValidationSpecificationFailure missingAuthnStatement() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_STATEMENT, false);
+    }
+
+    public static SamlValidationSpecificationFailure multipleAuthnStatements() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MULTIPLE_AUTHN_STATEMENTS, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnStatementAlreadyReceived(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.AUTHN_STATEMENT_ALREADY_RECEIVED, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingAssertionSubject(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUBJECT, id);
+    }
+
+    public static SamlValidationSpecificationFailure assertionSubjectHasNoNameID(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.SUBJECT_HAS_NO_NAME_ID, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingAssertionSubjectNameIDFormat(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUBJECT_NAME_ID_FORMAT, id);
+    }
+
+    public static SamlValidationSpecificationFailure illegalAssertionSubjectNameIDFormat(final String id, final String format) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.ILLEGAL_SUBJECT_NAME_ID_FORMAT, id, format);
+    }
+
+    public static SamlValidationSpecificationFailure unencryptedAssertion() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.UNENCRYPTED_ASSERTIONS);
+    }
+
+    public static SamlValidationSpecificationFailure missingSuccessUnEncryptedAssertions() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUCCESS_UNENCRYPTED);
+    }
+
+    public static SamlValidationSpecificationFailure nonSuccessHasUnEncryptedAssertions() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.NON_SUCCESS_HAS_UNENCRYPTED);
+    }
+
+    public static SamlValidationSpecificationFailure missingMatchingMds() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_MDS);
+    }
+
+    public static SamlValidationSpecificationFailure emptyIssuer() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_ISSUER);
+    }
+
+    public static SamlValidationSpecificationFailure illegalIssuerFormat(final String providedFormat, final String expectedFormat) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ILLEGAL_ISSUER_FORMAT, providedFormat, expectedFormat);
+    }
+
+    public static SamlValidationSpecificationFailure destinationMissing(final URI expectedUri) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_DESTINATION, expectedUri);
+    }
+
+    public static SamlValidationSpecificationFailure destinationEmpty(final URI expectedUri, final String destination) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_DESTINATION, expectedUri, destination);
+    }
+
+    public static SamlValidationSpecificationFailure destinationInvalid(URI uri, String endpoint) {
+        return new GenericHubProfileValidationSpecification("Destination is incorrect. Received: {0}{1}{2}", uri.getScheme(), uri.getPath(), endpoint);
+    }
+
+    public static SamlValidationSpecificationFailure assertionNotSigned(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ASSERTION_SIGNATURE_NOT_SIGNED, id);
+    }
+
+    public static SamlValidationSpecificationFailure assertionSignatureMissing(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ASSERTION_SIGNATURE, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingIssueInstant(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ISSUE_INSTANT, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingVersion(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_VERSION, id);
+    }
+
+    public static SamlValidationSpecificationFailure illegalVersion(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ILLEGAL_VERSION, id);
+    }
+
+    public static SamlValidationSpecificationFailure noSubjectConfirmationWithBearerMethod(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.NO_SUBJECT_CONF_WITH_BEARER_METHOD, id);
+    }
+
+    public static SamlValidationSpecificationFailure emptyIPAddress(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_IP_ADDRESS, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingIPAddress(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_IP_ADDRESS, id);
+    }
+
+    public static SamlValidationSpecificationFailure duplicateMatchingDataset(final String id, final String responseIssuerId) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.DUPLICATE_MATCHING_DATASET, id, responseIssuerId);
+    }
+
+    public static SamlValidationSpecificationFailure mdsStatementMissing() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_STATEMENT_MISSING);
+    }
+
+    public static SamlValidationSpecificationFailure mdsMultipleStatements() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_MULTIPLE_STATEMENTS);
+    }
+
+    public static SamlValidationSpecificationFailure mdsAttributeNotRecognised(final String attributeName) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_ATTRIBUTE_NOT_RECOGNISED, attributeName);
+    }
+
+    public static SamlValidationSpecificationFailure emptyAttribute(final String attributeName) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_ATTRIBUTE, attributeName);
+    }
+
+    public static SamlValidationSpecificationFailure attributeWithIncorrectType(final String attributeName, final QName expected, final QName received) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ATTRIBUTE_HAS_INCORRECT_TYPE, attributeName, expected, received);
+    }
+
+    public static SamlValidationSpecificationFailure illegalRequestVersionNumber() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.INCORRECT_VERSION);
+    }
+
+    public static SamlValidationSpecificationFailure requestTooOld(String requestId, DateTime issueInstant, DateTime currentTime) {
+        return new RequestFreshnessValidationSpecification(RequestFreshnessValidationSpecification.REQUEST_TOO_OLD, requestId, issueInstant, currentTime);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestId() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestIssueInstant(final String requestId) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_ISSUE_INSTANT, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestVersion(final String requestId) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_VERSION, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure nestedSubStatusCodesBreached(int subStatusCodeLimit) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.SUB_STATUS_CODE_LIMIT_EXCEEDED, subStatusCodeLimit);
+    }
+
+    public static SamlValidationSpecificationFailure invalidStatusCode(final String statusCode) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_STATUS_CODE, statusCode);
+    }
+
+    public static SamlValidationSpecificationFailure invalidSubStatusCode(final String subStatusCode, final String statusCode) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_SUB_STATUS_CODE, subStatusCode, statusCode);
+    }
+
+    public static SamlValidationSpecificationFailure subStatusMustBeOneOf(final String subStatus, final String code1, final String code2, final String code3) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.STATUS_CODE_MUST_BE_ONE_OF, subStatus, code1, code2, code3);
+    }
+
+    public static SamlValidationSpecificationFailure missingSubStatus() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUB_STATUS);
+    }
+
+    public static SamlValidationSpecificationFailure unexpectedNumberOfAssertions(int expected, int actual) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.UNEXPECTED_NUMBER_OF_ASSERTIONS, expected, actual);
+    }
+
+    public static SamlValidationSpecificationFailure notMatchInResponseTo(final String inResponseTo, final String requestId) {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.IN_RESPONSE_TO_DOES_NOT_MATCH, inResponseTo, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure incorrectRecipientFormat(String recipient, String expectedRecipient) {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.INCORRECT_RECIPIENT_FORMAT, recipient, expectedRecipient);
+    }
+
+    public static SamlValidationSpecificationFailure missingSubjectConfirmationData() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.MISSING_SUBJECT_CONFIRMATION_DATA);
+    }
+
+    public static SamlValidationSpecificationFailure missingBearerInResponseTo() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_INRESPONSETO_VALUE);
+    }
+
+    public static SamlValidationSpecificationFailure missingBearerRecipient() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_RECIPIENT);
+    }
+
+    public static SamlValidationSpecificationFailure missingNotOnOrAfter() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_NOT_ON_OR_AFTER);
+    }
+
+    public static SamlValidationSpecificationFailure exceededNotOnOrAfter(DateTime expiredTime) {
+        return new BearerSubjectConfirmationValidationSpecification(format(BearerSubjectConfirmationValidationSpecification.EXCEEDED_NOT_ON_OR_AFTER, expiredTime));
+    }
+
+    public static SamlValidationSpecificationFailure notBeforeExists() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NOT_BEFORE_ATTRIBUTE_EXISTS);
+    }
+
+    public static SamlValidationSpecificationFailure missingOrEmptyEntityID() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_OR_EMPTY_ENTITY_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingCacheDurationAndValidUntil() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_CACHEDUR_VALIDUNTIL);
+    }
+
+    public static SamlValidationSpecificationFailure missingRoleDescriptor() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ROLE_DESCRIPTOR);
+    }
+
+    public static SamlValidationSpecificationFailure missingKeyDescriptor() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY_DESCRIPTOR);
+    }
+
+    public static SamlValidationSpecificationFailure missingKeyInfo() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY_INFO);
+    }
+
+    public static SamlValidationSpecificationFailure missingX509Data() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_X509DATA);
+    }
+
+    public static SamlValidationSpecificationFailure missingX509Certificate() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_X509CERT);
+    }
+
+    public static SamlValidationSpecificationFailure emptyX509Certificiate() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_X509CERT);
+    }
+
+    public static SamlValidationSpecificationFailure missingOrganization() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ORGANIZATION);
+    }
+
+    public static SamlValidationSpecificationFailure missingDisplayName() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_DISPLAY_NAME);
+    }
+
+    public static SamlValidationSpecificationFailure missingSignature() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_SIGNATURE);
+    }
+
+    public static SamlValidationSpecificationFailure signatureNotSigned() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.SIGNATURE_NOT_SIGNED);
+    }
+
+    public static SamlValidationSpecificationFailure missingIssuer() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ISSUER);
+    }
+
+    public static SamlValidationSpecificationFailure missingId() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingKey(final String key, final String entity) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY, key, entity);
+    }
+
+    public static SamlValidationSpecificationFailure unsupportedKey(final String key) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNSUPPORTED_KEY, key);
+    }
+
+    public static SamlValidationSpecificationFailure invalidRequestID() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_REQUEST_ID);
+    }
+
+    public static SamlValidationSpecificationFailure invalidRelayState(String relayState) {
+        return new RelayStateValidationSpecification(RelayStateValidationSpecification.INVALID_RELAY_STATE, relayState);
+    }
+
+    public static SamlValidationSpecificationFailure relayStateContainsInvalidCharacter(String invalidCharacter, String relayState) {
+        return new RelayStateValidationSpecification(RelayStateValidationSpecification.INVALID_RELAY_STATE_CHARACTER, invalidCharacter, relayState);
+    }
+
+    public static SamlValidationSpecificationFailure invalidAttributeLanguageInAssertion(final String name, final String language) {
+        return new InvalidAttributeLanguageInAssertion(name, language);
+    }
+
+    public static SamlValidationSpecificationFailure invalidFraudAttribute(String message) {
+        return new SamlValidationSpecification(SamlValidationSpecification.DESERIALIZATION_ERROR, message);
+    }
+
+    public static SamlValidationSpecificationWarning invalidAttributeNameFormat(final String nameFormat) {
+        return new InvalidAttributeNameFormat(nameFormat);
+    }
+
+    public static SamlValidationSpecificationFailure mismatchedPersistentIdentifiers() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISMATCHED_PIDS);
+    }
+
+    public static SamlValidationSpecificationFailure mismatchedIssuers() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS);
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subject/AssertionSubjectValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subject/AssertionSubjectValidator.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.saml.core.validators.subject;
+
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+
+import java.util.stream.Stream;
+
+public class AssertionSubjectValidator {
+
+    public void validate(
+            Subject subject,
+            String assertionId) {
+
+        if (subject == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingAssertionSubject(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subject.getNameID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSubjectHasNoNameID(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subject.getNameID().getFormat() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingAssertionSubjectNameIDFormat(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        boolean correctNameIdType = Stream
+                .of(NameIDType.PERSISTENT, NameIDType.TRANSIENT)
+                .anyMatch(type -> type.equals(subject.getNameID().getFormat()));
+
+        if (!correctNameIdType) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalAssertionSubjectNameIDFormat(assertionId, subject.getNameID().getFormat());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subjectconfirmation/AssertionSubjectConfirmationValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subjectconfirmation/AssertionSubjectConfirmationValidator.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.validation.subjectconfirmation;
+
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+
+public class AssertionSubjectConfirmationValidator extends BasicAssertionSubjectConfirmationValidator {
+
+    public void validate(
+            SubjectConfirmation subjectConfirmation,
+            String requestId,
+            String expectedRecipientId) {
+
+        super.validate(subjectConfirmation);
+
+        SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
+
+        if (!subjectConfirmationData.getInResponseTo().equals(requestId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.notMatchInResponseTo(subjectConfirmationData.getInResponseTo(), requestId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!subjectConfirmationData.getRecipient().equals(expectedRecipientId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.incorrectRecipientFormat(subjectConfirmationData.getRecipient(), expectedRecipientId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+ }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subjectconfirmation/BasicAssertionSubjectConfirmationValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/subjectconfirmation/BasicAssertionSubjectConfirmationValidator.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.core.validation.subjectconfirmation;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+
+public class BasicAssertionSubjectConfirmationValidator {
+
+    public void validate(SubjectConfirmation subjectConfirmation) {
+
+        final SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
+
+        if (subjectConfirmationData == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingSubjectConfirmationData();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (subjectConfirmationData.getInResponseTo() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingBearerInResponseTo();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subjectConfirmationData.getRecipient() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingBearerRecipient();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        final DateTime notOnOrAfter = subjectConfirmationData.getNotOnOrAfter();
+        if (notOnOrAfter == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingNotOnOrAfter();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        final DateTime now = DateTime.now();
+        if (notOnOrAfter.isEqual(now) || notOnOrAfter.isBefore(now)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.exceededNotOnOrAfter(notOnOrAfter);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (subjectConfirmationData.getNotBefore() != null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.notBeforeExists();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AttributeQueryToElementTransformer.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AttributeQueryToElementTransformer.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.core.domain.SamlAttributeQueryAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+
+import java.util.function.Function;
+
+public class AttributeQueryToElementTransformer implements Function<AttributeQuery, Element> {
+
+    private final SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator;
+    private final SamlAttributeQueryAssertionSignatureSigner samlAttributeQueryAssertionSignatureSigner;
+    private final SamlSignatureSigner<AttributeQuery> samlSignatureSigner;
+    private final XmlObjectToElementTransformer<AttributeQuery> xmlObjectToElementTransformer;
+    private final SamlAttributeQueryAssertionEncrypter encrypter;
+
+    @Inject
+    public AttributeQueryToElementTransformer(
+            final SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator,
+            final SamlAttributeQueryAssertionSignatureSigner samlAttributeQueryAssertionSignatureSigner,
+            final SamlSignatureSigner<AttributeQuery> samlSignatureSigner,
+            final XmlObjectToElementTransformer<AttributeQuery> xmlObjectToElementTransformer,
+            final SamlAttributeQueryAssertionEncrypter encrypter) {
+
+        this.signatureCreator = signatureCreator;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.samlAttributeQueryAssertionSignatureSigner = samlAttributeQueryAssertionSignatureSigner;
+        this.xmlObjectToElementTransformer = xmlObjectToElementTransformer;
+        this.encrypter = encrypter;
+    }
+
+    @Override
+    public Element apply(final AttributeQuery attributeQuery) {
+        final AttributeQuery queryWithSignature = signatureCreator.addUnsignedSignatureTo(attributeQuery);
+        final AttributeQuery queryWithSignedAssertions =
+                samlAttributeQueryAssertionSignatureSigner.signAssertions(queryWithSignature);
+        final AttributeQuery queryWithEncryptedAssertions =
+                encrypter.encryptAssertions(queryWithSignedAssertions);
+        final AttributeQuery signedQuery =
+                samlSignatureSigner.sign(queryWithEncryptedAssertions);
+        return xmlObjectToElementTransformer.apply(signedQuery);
+    }
+
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SamlAttributeQueryAssertionSignatureSigner.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SamlAttributeQueryAssertionSignatureSigner.java
@@ -1,0 +1,55 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+
+import static org.opensaml.xmlsec.signature.support.Signer.signObject;
+
+public class SamlAttributeQueryAssertionSignatureSigner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SamlAttributeQueryAssertionSignatureSigner.class);
+
+    private final IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever;
+    private final OpenSamlXmlObjectFactory samlObjectFactory;
+    private final String hubEntityId;
+
+    public SamlAttributeQueryAssertionSignatureSigner(
+            IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever,
+            OpenSamlXmlObjectFactory samlObjectFactory,
+            String hubEntityId) {
+
+        this.keyStoreCredentialRetriever = keyStoreCredentialRetriever;
+        this.samlObjectFactory = samlObjectFactory;
+        this.hubEntityId = hubEntityId;
+    }
+
+    public AttributeQuery signAssertions(AttributeQuery attributeQuery) {
+        LOG.debug("Sign attribute query's C3 assertion's signatures");
+
+        for (SubjectConfirmation subjectConfirmation : attributeQuery.getSubject().getSubjectConfirmations()) {
+            for (XMLObject xmlObject : subjectConfirmation.getSubjectConfirmationData().getUnknownXMLObjects(Assertion.TYPE_NAME)) {
+                Assertion assertion = (Assertion) xmlObject;
+                if (assertion.getIssuer().getValue().equals(hubEntityId)) {
+                    assertion.setSignature(samlObjectFactory.createSignature());
+                    assertion.getSignature().setSigningCredential(keyStoreCredentialRetriever.getSigningCredential());
+                    try {
+                        XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(assertion).marshall(assertion);
+                        signObject(assertion.getSignature());
+                    } catch (SignatureException | MarshallingException e) {
+                        throw new IllegalStateException("Unable to sign assertion.", e);
+                    }
+                }
+            }
+        }
+        return attributeQuery;
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SigningRequestAbstractTypeSignatureCreator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SigningRequestAbstractTypeSignatureCreator.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.security.SignatureFactory;
+
+public class SigningRequestAbstractTypeSignatureCreator<T extends RequestAbstractType> {
+    private final SignatureFactory signatureFactory;
+
+    public SigningRequestAbstractTypeSignatureCreator(SignatureFactory signatureFactory) {
+        this.signatureFactory = signatureFactory;
+    }
+
+    public T addUnsignedSignatureTo(T requestAbstractType) {
+        Signature signature = signatureFactory.createSignature(requestAbstractType.getID());
+        requestAbstractType.setSignature(signature);
+        return requestAbstractType;
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypterTest.java
@@ -1,0 +1,123 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.encryption.Encrypter;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.support.EncryptionException;
+import uk.gov.ida.saml.core.domain.SamlAttributeQueryAssertionEncrypter;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder.anAttributeQuery;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SamlAttributeQueryAssertionEncrypterTest {
+
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
+    public Credential credential;
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
+    public KeyStoreBackedEncryptionCredentialResolver credentialResolver;
+    public final EntityToEncryptForLocator entityToEncryptForLocator = mock(EntityToEncryptForLocator.class);
+    public final EncrypterFactory encrypterFactory = mock(EncrypterFactory.class);
+    public final Encrypter encrypter = mock(Encrypter.class);
+
+    public AttributeQuery attributeQuery;
+    public EncryptedAssertion encryptedAssertion;
+    public SamlAttributeQueryAssertionEncrypter samlAttributeQueryAssertionEncrypter;
+    public Assertion assertion;
+
+    @Before
+    public void setUp() throws Exception {
+        assertion = anAssertion().buildUnencrypted();
+        attributeQuery = anAttributeQueryWithAssertion(assertion);
+        encryptedAssertion = anAssertion().build();
+        when(entityToEncryptForLocator.fromRequestId(anyString())).thenReturn("some id");
+        when(credentialResolver.getEncryptingCredential("some id")).thenReturn(credential);
+        when(encrypterFactory.createEncrypter(credential)).thenReturn(encrypter);
+        when(encrypter.encrypt(assertion)).thenReturn(encryptedAssertion);
+        samlAttributeQueryAssertionEncrypter = new SamlAttributeQueryAssertionEncrypter(
+                credentialResolver,
+                encrypterFactory,
+                entityToEncryptForLocator
+        );
+    }
+
+    @Test
+    public void shouldConvertAssertionIntoEncryptedAssertion() throws EncryptionException {
+        final AttributeQuery decoratedAttributeQuery = samlAttributeQueryAssertionEncrypter.encryptAssertions(attributeQuery);
+
+        final SubjectConfirmationData subjectConfirmationData = decoratedAttributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+        final List<XMLObject> encryptedAssertions = subjectConfirmationData
+                .getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME);
+        assertThat(encryptedAssertions.size()).isEqualTo(1);
+        assertThat((EncryptedAssertion) encryptedAssertions.get(0)).isEqualTo(encryptedAssertion);
+
+        final List<XMLObject> unencryptedAssertions = subjectConfirmationData
+                .getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(unencryptedAssertions.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void decorate_shouldWrapEncryptionAssertionInSamlExceptionWhenEncryptionFails() throws EncryptionException {
+        EncryptionException encryptionException = new EncryptionException("BLAM!");
+        when(encrypter.encrypt(assertion)).thenThrow(encryptionException);
+
+        SamlAttributeQueryAssertionEncrypter assertionEncrypter =
+                new SamlAttributeQueryAssertionEncrypter(
+                        credentialResolver,
+                        encrypterFactory,
+                        entityToEncryptForLocator
+                );
+
+        try {
+            assertionEncrypter.encryptAssertions(attributeQuery);
+        } catch (Exception e) {
+            assertThat(e.getCause()).isEqualTo(encryptionException);
+            return;
+        }
+        fail("Should never get here");
+    }
+
+    private AttributeQuery anAttributeQueryWithAssertion(final Assertion assertion) {
+        return anAttributeQuery()
+                    .withSubject(
+                            aSubject()
+                                    .withSubjectConfirmation(
+                                            aSubjectConfirmation()
+                                                    .withSubjectConfirmationData(
+                                                            aSubjectConfirmationData()
+                                                                    .addAssertion(assertion)
+                                                                    .build()
+                                                    )
+                                                    .build()
+                                    )
+                                    .build()
+                    )
+                    .build();
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSignerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSignerTest.java
@@ -1,0 +1,119 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.security.credential.Credential;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.PrivateKeyStoreFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.hub.transformers.outbound.SamlAttributeQueryAssertionSignatureSigner;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder.anAttributeQuery;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+import static uk.gov.ida.shared.utils.string.StringEncoding.toBase64Encoded;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SamlAttributeQueryAssertionSignatureSignerTest {
+
+    private OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    @Mock
+    private IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever;
+    public SamlAttributeQueryAssertionSignatureSigner assertionSignatureSigner;
+
+    @Before
+    public void setUp() throws Exception {
+        assertionSignatureSigner = new SamlAttributeQueryAssertionSignatureSigner(
+                keyStoreCredentialRetriever,
+                samlObjectFactory,
+                TestEntityIds.HUB_ENTITY_ID);
+    }
+
+    @Test
+    public void decorate_shouldSetSignatureOnAssertionIssuedByTheHub() {
+        Credential hubSigningCredential = createHubSigningCredential();
+        when(keyStoreCredentialRetriever.getSigningCredential()).thenReturn(hubSigningCredential);
+        AttributeQuery inputAttributeQuery = anAttributeQueryWithHubSignature();
+
+        AttributeQuery attributeQuery = assertionSignatureSigner.signAssertions(inputAttributeQuery);
+
+        final Credential assertionSigningCredential = getAssertionSigningCredential(attributeQuery);
+        assertThat(assertionSigningCredential).isSameAs(hubSigningCredential);
+        verify(keyStoreCredentialRetriever, times(1)).getSigningCredential();
+        verifyNoMoreInteractions(keyStoreCredentialRetriever);
+    }
+
+    private Credential createHubSigningCredential() {
+        return new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT, toBase64Encoded(
+                new PrivateKeyStoreFactory().create(TestEntityIds.HUB_ENTITY_ID).getSigningPrivateKey()
+                        .getEncoded()
+        )).getSigningCredential();
+    }
+
+    private Credential getAssertionSigningCredential(final AttributeQuery attributeQuery) {
+        Assertion cycle3DatasetAssertion = (Assertion) attributeQuery.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.TYPE_NAME).get(0);
+        return cycle3DatasetAssertion.getSignature().getSigningCredential();
+    }
+
+    private AttributeQuery anAttributeQueryWithHubSignature() {
+        return anAttributeQuery()
+                .withSubject(
+                        aSubject()
+                                .withSubjectConfirmation(
+                                        aSubjectConfirmation()
+                                                .withSubjectConfirmationData(
+                                                        aSubjectConfirmationData()
+                                                                .addAssertion(
+                                                                        unencyptedCycle3DatasetAssertion()
+                                                                ).build()
+                                                ).build()
+                                ).build()
+                ).build();
+    }
+
+    private Assertion unencyptedCycle3DatasetAssertion() {
+        return anAssertion()
+                .withIssuer(
+                        hubIssuer()
+                )
+                .addAttributeStatement(
+                        anAttributeStatement()
+                                .addAttribute(
+                                        aSimpleStringAttribute()
+                                                .withName(
+                                                        "NINO"
+                                                )
+                                                .withSimpleStringValue(
+                                                        "MyNINO"
+                                                )
+                                                .build()
+                                )
+                                .build()
+                )
+                .buildUnencrypted();
+    }
+
+    private Issuer hubIssuer() {
+        return anIssuer().withIssuerId(TestEntityIds.HUB_ENTITY_ID).build();
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreatorTest.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.hub.transformers.outbound.SigningRequestAbstractTypeSignatureCreator;
+import uk.gov.ida.saml.security.SignatureFactory;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SigningRequestAbstractTypeSignatureCreatorTest {
+
+    private SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator;
+    @Mock
+    private SignatureFactory signatureFactory;
+    private static final String id = "response-id";
+    @Before
+    public void setup() {
+        signatureCreator = new SigningRequestAbstractTypeSignatureCreator<>(signatureFactory);
+    }
+
+    @Test
+    public void decorate_shouldGetSignatureAndAssignIt() {
+        AttributeQuery response = mock(AttributeQuery.class);
+        when(response.getID()).thenReturn(id);
+
+        signatureCreator.addUnsignedSignatureTo(response);
+
+        verify(signatureFactory).createSignature(id);
+    }
+
+    @Test
+    public void decorate_shouldAssignSignatureToResponse() {
+        AttributeQuery response = mock(AttributeQuery.class);
+        Signature signature = mock(Signature.class);
+        when(response.getID()).thenReturn(id);
+        when(signatureFactory.createSignature(id)).thenReturn(signature);
+
+        signatureCreator.addUnsignedSignatureTo(response);
+
+        verify(response).setSignature(signature);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidatorTest.java
@@ -1,0 +1,76 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder;
+import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
+
+import static java.util.Arrays.asList;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidAttributeLanguageInAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidFraudAttribute;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionAttributeStatementValidatorTest {
+
+    private AssertionAttributeStatementValidator validator;
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new AssertionAttributeStatementValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowWhenAttributesIsNotEnGb() throws Exception {
+        Attribute validAttributeOne = aSimpleStringAttribute().build();
+        PersonName validFirstNameAttribute = openSamlXmlObjectFactory.createPersonNameAttributeValue("Dave");
+        validAttributeOne.getAttributeValues().add(validFirstNameAttribute);
+
+        Attribute validAttributeTwo = aSimpleStringAttribute().build();
+        PersonName validSurnameAttributeValue = openSamlXmlObjectFactory.createPersonNameAttributeValue("Jones");
+        validAttributeTwo.getAttributeValues().add(validSurnameAttributeValue);
+
+        Attribute invalidMiddlenameAttribute = aSimpleStringAttribute().build();
+        PersonName invalidMiddlenameAttributeValue = openSamlXmlObjectFactory.createPersonNameAttributeValue("Middle");
+        invalidMiddlenameAttributeValue.setLanguage("en-US");
+        invalidMiddlenameAttribute.getAttributeValues().add(invalidMiddlenameAttributeValue);
+
+        final Assertion assertion = AssertionBuilder.anAssertion()
+                .addAttributeStatement(anAttributeStatement().build())
+                .addAttributeStatement(anAttributeStatement().build())
+                .buildUnencrypted();
+
+        assertion.getAttributeStatements().get(0).getAttributes().add(validAttributeOne);
+        assertion.getAttributeStatements().get(1).getAttributes().addAll(asList(validAttributeTwo, invalidMiddlenameAttribute));
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validate(assertion),
+                invalidAttributeLanguageInAssertion(invalidMiddlenameAttribute.getName(), invalidMiddlenameAttributeValue.getLanguage())
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowWhenFraudEventNotCorrect() throws Exception{
+        final Assertion assertion = AssertionBuilder.anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(IdpFraudEventIdAttributeBuilder.anIdpFraudEventIdAttribute().buildInvalidAttribute()).build())
+                .buildUnencrypted();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validateFraudEvent(assertion),
+                invalidFraudAttribute(AssertionAttributeStatementValidator.INVALID_FRAUD_EVENT_TYPE)
+        );
+
+    }
+
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -1,0 +1,148 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
+import uk.gov.ida.saml.core.validation.assertion.AssertionValidator;
+import uk.gov.ida.saml.core.validation.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionValidatorTest {
+
+    @Mock
+    private uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator subjectValidator;
+    @Mock
+    private IssuerValidator issuerValidator;
+    @Mock
+    private AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+    @Mock
+    private BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator;
+
+    private AssertionValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, basicAssertionSubjectConfirmationValidator);
+    }
+
+    @Test
+    public void validate_shouldDelegateSubjectValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(subjectValidator).validate(assertion.getSubject(), assertion.getID());
+    }
+
+    @Test
+    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().withSubjectConfirmation(subjectConfirmation).build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(basicAssertionSubjectConfirmationValidator).validate(subjectConfirmation);
+    }
+
+    @Test
+    public void validate_shouldDelegateAttributeValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(assertionAttributeStatementValidator).validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.assertionSignatureMissing(someID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
+        String someID = UUID.randomUUID().toString();
+
+        Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.assertionNotSigned(someID));
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfAllAssertionsAreSigned() throws Exception {
+        Assertion assertion = anAssertion().buildUnencrypted();
+
+        validator.validate(assertion, "", assertion.getID());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withId(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfVersionIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
+        Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));
+    }
+
+    private void assertExceptionMessage(
+            final Assertion assertion,
+            SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(assertion, "", "");
+                    }
+                },
+                failure
+        );
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidatorTest.java
@@ -1,0 +1,84 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder;
+import uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder;
+import uk.gov.ida.saml.core.test.builders.SubjectBuilder;
+import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
+import uk.gov.ida.saml.core.validation.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validation.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class IdentityProviderAssertionValidatorTest {
+
+    @Mock
+    private uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator subjectValidator;
+    @Mock
+    private IssuerValidator issuerValidator;
+    @Mock
+    private AssertionSubjectConfirmationValidator subjectConfirmationValidator;
+    @Mock
+    private AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+
+    @Test
+    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String expectedRecipientId = UUID.randomUUID().toString();
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
+        Assertion assertion = anAssertion()
+                .withSubject(SubjectBuilder.aSubject().withSubjectConfirmation(subjectConfirmation).build())
+                .buildUnencrypted();
+
+        IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+        validator.validate(assertion, requestId, expectedRecipientId);
+
+        verify(subjectConfirmationValidator).validate(subjectConfirmation, requestId, expectedRecipientId);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfNoSubjectConfirmationMethodAttributeHasBearerValue() throws Exception {
+        String someID = UUID.randomUUID().toString();
+        final Assertion assertion = anAssertion().withId(someID).addAuthnStatement(anAuthnStatement().build()).withSubject(SubjectBuilder.aSubject().withSubjectConfirmation(aSubjectConfirmation().withMethod("invalid").build()).build()).buildUnencrypted();
+        final IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validateSubject(assertion, "", ""),
+                SamlTransformationErrorFactory.noSubjectConfirmationWithBearerMethod(assertion.getID())
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfInvalidFraudEventTypeUsed(){
+        final AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().withAuthnContextClasRefValue(AuthnContext.LEVEL_X.getUri()).build();
+        final org.opensaml.saml.saml2.core.AuthnContext authnContext = anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build();
+
+        String someID = UUID.randomUUID().toString();
+        final Assertion assertion =
+                anAssertion().withId(someID)
+                .addAttributeStatement(AttributeStatementBuilder.anAttributeStatement().addAttribute(IdpFraudEventIdAttributeBuilder.anIdpFraudEventIdAttribute().buildInvalidAttribute()).build())
+                .addAuthnStatement(anAuthnStatement().withAuthnContext(authnContext).build())
+                .buildUnencrypted();
+        final IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+        validator.validateSubject(assertion, someID, UUID.randomUUID().toString());
+        verify(assertionAttributeStatementValidator).validateFraudEvent(assertion);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.saml.core.validators.subject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.NameIdBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification;
+
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionSubjectValidatorTest {
+
+    private static final String ASSERTION_ID = "some-assertion-id";
+
+    private static uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectElementIsMissing() throws Exception {
+        assertExceptionMessage(null, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.missingAssertionSubject(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdIsMissing() throws Exception {
+        final Subject subject = aSubject().withNameId(null).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.assertionSubjectHasNoNameID(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdFormatAttributeIsMissing() throws Exception {
+        final Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(null).build()).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.missingAssertionSubjectNameIDFormat(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldSuccessfullyValidateMultipleNameIdFormats() throws Exception {
+        Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(NameIDType.PERSISTENT).build()).build();
+        assert(subject.getNameID().getFormat().equals(NameIDType.PERSISTENT));
+
+        subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(NameIDType.TRANSIENT).build()).build();
+        assert(subject.getNameID().getFormat().equals(NameIDType.TRANSIENT));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdFormatAttributeHasInvalidValue() throws Exception {
+        final Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat("Invalid").build()).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.illegalAssertionSubjectNameIDFormat(ASSERTION_ID, subject.getNameID().getFormat()));
+    }
+
+    public static void assertExceptionMessage(
+            final Subject subject,
+            Class<? extends SamlValidationSpecificationFailure> errorClass,
+            SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(() -> validator.validate(subject, ASSERTION_ID), failure);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidatorTest.java
@@ -1,0 +1,74 @@
+package uk.gov.ida.saml.core.validators.subjectconfirmation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.subjectconfirmation.AssertionSubjectConfirmationValidator;
+
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionSubjectConfirmationValidatorTest {
+
+    private static final String REQUEST_ID = "some-request-id";
+
+    private AssertionSubjectConfirmationValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AssertionSubjectConfirmationValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectConfirmationDataRecipientAttributeDoesNotMatchTheExpectedIssuerId() throws Exception {
+        final String expectedRecipientId = TestEntityIds.HUB_ENTITY_ID;
+        final String actualRecipientId = TestEntityIds.TEST_RP;
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder()
+                        .withRecipient(actualRecipientId)
+                        .build())
+                .build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.incorrectRecipientFormat(actualRecipientId, expectedRecipientId), expectedRecipientId);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectConfirmationDataInResponseToAttributeIsNotTheOriginalRequestId() throws Exception {
+        final String subjectInResponseTo = "an-incorrect-request-id";
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(SubjectConfirmationDataBuilder.aSubjectConfirmationData()
+                        .withInResponseTo(subjectInResponseTo)
+                        .build())
+                .build();
+
+        assertExceptionMessage(
+                subjectConfirmation,
+                SamlTransformationErrorFactory.notMatchInResponseTo(subjectInResponseTo, REQUEST_ID),
+                subjectConfirmation.getSubjectConfirmationData().getRecipient());
+    }
+
+    private void assertExceptionMessage(
+            final SubjectConfirmation subjectConfirmation,
+            SamlValidationSpecificationFailure failure, final String recipient) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(subjectConfirmation, REQUEST_ID, recipient);
+                    }
+                },
+                failure
+        );
+    }
+
+    private SubjectConfirmationDataBuilder createSubjectConfirmationDataBuilder() {
+        return SubjectConfirmationDataBuilder.aSubjectConfirmationData().withInResponseTo(REQUEST_ID);
+    }
+}

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/HardCodedKeyStore.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/HardCodedKeyStore.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.saml.core.test;
+
+import org.apache.commons.codec.binary.Base64;
+import uk.gov.ida.common.shared.security.InternalPublicKeyStore;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.SigningKeyStore;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HardCodedKeyStore implements SigningKeyStore, EncryptionKeyStore, InternalPublicKeyStore, PublicKeyInputStreamFactory {
+
+    private final PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+    private final String entityId;
+
+    public HardCodedKeyStore(String whoAmI) {
+        this.entityId = whoAmI;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity(String entityId) {
+        List<String> certs = Arrays.asList(TestCertificateStrings.PUBLIC_SIGNING_CERTS.get(entityId));
+        return certs.stream().map(cert -> publicKeyFactory.createPublicKey(cert)).collect(Collectors.toList());
+    }
+
+    @Override
+    public PublicKey getEncryptionKeyForEntity(String entityId) {
+        return getPrimaryEncryptionKeyForEntity(entityId);
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity() {
+        return getVerifyingKeysForEntity(this.entityId);
+    }
+
+    @Override
+    public InputStream createInputStream(String publicKeyUri) {
+        switch (publicKeyUri) {
+            case "../deploy/keys/test-rp.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT.getBytes());
+            case "../deploy/keys/test-rp.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY));
+            case "../deploy/keys/hub_encryption.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT.getBytes());
+            case "../deploy/keys/hub_signing.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT.getBytes());
+            case "../deploy/keys/hub_encryption.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY));
+            case "../deploy/keys/hub_signing.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY));
+            default:
+                throw new RuntimeException("Cert not found: " + publicKeyUri);
+        }
+    }
+
+    public PublicKey getPrimaryEncryptionKeyForEntity(String entityId) {
+        String cert = TestCertificateStrings.getPrimaryPublicEncryptionCert(entityId);
+
+        return publicKeyFactory.createPublicKey(cert);
+    }
+
+    public PublicKey getSecondaryEncryptionKeyForEntity(String entityId) {
+        String cert = TestCertificateStrings.getSecondaryPublicEncryptionCert(entityId);
+
+        return publicKeyFactory.createPublicKey(cert);
+    }
+
+}

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/IdpFraudEventIdAttributeBuilder.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/IdpFraudEventIdAttributeBuilder.java
@@ -1,0 +1,51 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.core.extensions.impl.StringBasedMdsAttributeValueBuilder;
+
+import javax.xml.namespace.QName;
+import java.util.Optional;
+
+public class IdpFraudEventIdAttributeBuilder {
+
+    private static final String INVALID_TYPE_LOCAL_NAME = "InvalidFraudEventType";
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> value = Optional.ofNullable("default-event-id");
+
+    public static IdpFraudEventIdAttributeBuilder anIdpFraudEventIdAttribute() {
+        return new IdpFraudEventIdAttributeBuilder();
+    }
+
+    public Attribute build() {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+        if (value.isPresent()){
+            IdpFraudEventId attributeValue = openSamlXmlObjectFactory.createIdpFraudEventAttributeValue(value.get());
+            attribute.getAttributeValues().add(attributeValue);
+        }
+
+        return attribute;
+    }
+
+    public Attribute buildInvalidAttribute() {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+        if (value.isPresent()){
+            QName typeName = new QName(IdaConstants.IDA_NS, INVALID_TYPE_LOCAL_NAME, IdaConstants.IDA_PREFIX);
+            StringValueSamlObject idpFraudEventId = new StringBasedMdsAttributeValueBuilder().buildObject(IdpFraudEventId.DEFAULT_ELEMENT_NAME, typeName);
+            idpFraudEventId.setValue(value.get());
+            attribute.getAttributeValues().add(idpFraudEventId);
+        }
+
+        return attribute;
+    }
+
+    public IdpFraudEventIdAttributeBuilder withValue(String value){
+        this.value = Optional.ofNullable(value);
+        return this;
+    }
+}

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/VerifiedAttributeValueBuilder.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/VerifiedAttributeValueBuilder.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AttributeValue;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class VerifiedAttributeValueBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    private boolean value;
+
+    public static VerifiedAttributeValueBuilder aVerifiedValue() {
+        return new VerifiedAttributeValueBuilder();
+    }
+
+    public AttributeValue build() {
+        return openSamlXmlObjectFactory.createVerifiedAttributeValue(value);
+    }
+
+    public VerifiedAttributeValueBuilder withValue(boolean value) {
+        this.value = value;
+        return this;
+    }
+
+}

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/matchers/SignableSAMLObjectBaseMatcher.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/matchers/SignableSAMLObjectBaseMatcher.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.core.test.matchers;
+
+import org.assertj.core.api.Condition;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.validators.SingleCertificateSignatureValidator;
+import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.SignatureValidator;
+
+public class SignableSAMLObjectBaseMatcher extends Condition<SignableSAMLObject> {
+
+    private final SamlMessageSignatureValidator samlMessageSignatureValidator;
+
+    public SignableSAMLObjectBaseMatcher(SamlMessageSignatureValidator samlMessageSignatureValidator) {
+        this.samlMessageSignatureValidator = samlMessageSignatureValidator;
+    }
+
+    public static SignableSAMLObjectBaseMatcher signedBy(String publicCert, String privateKey) {
+        final SignatureValidator signatureValidator = new SingleCertificateSignatureValidator(
+                new TestCredentialFactory(publicCert, privateKey).getSigningCredential()
+        );
+        return new SignableSAMLObjectBaseMatcher(new SamlMessageSignatureValidator(signatureValidator));
+    }
+
+    @Override
+    public boolean matches(SignableSAMLObject value) {
+        if (value instanceof Response) {
+            return samlMessageSignatureValidator.validate((Response) value, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else if (value instanceof RequestAbstractType) {
+            return samlMessageSignatureValidator.validate((RequestAbstractType) value, SPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else if (value instanceof Assertion) {
+            return samlMessageSignatureValidator.validate((Assertion) value, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else {
+            throw new IllegalArgumentException("Don't know how to validate signature of a " + value.getClass());
+        }
+    }
+}

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/validators/SingleCertificateSignatureValidator.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/validators/SingleCertificateSignatureValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.core.test.validators;
+
+import net.shibboleth.utilities.java.support.resolver.Criterion;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.StaticCredentialResolver;
+import org.opensaml.security.trust.TrustEngine;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.security.SignatureValidator;
+
+import javax.xml.namespace.QName;
+import java.util.Collections;
+import java.util.List;
+
+public class SingleCertificateSignatureValidator extends SignatureValidator {
+    private final Credential credential;
+
+    public SingleCertificateSignatureValidator(Credential credential) {
+        this.credential = credential;
+    }
+
+    @Override
+    protected TrustEngine<Signature> getTrustEngine(String entityId) {
+        CredentialResolver credResolver = new StaticCredentialResolver(credential);
+        KeyInfoCredentialResolver kiResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+        return new ExplicitKeySignatureTrustEngine(credResolver, kiResolver);
+    }
+
+    @Override
+    protected List<Criterion> getAdditionalCriteria(String entityId, QName role) {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
- PR 1 of 3
- Move the SAML classes that are used by the MSA to a more appropriate shared location, so that the MSA does not have to pull in hub-saml.