### PR TITLE
build verify-saml-libs with OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
-  - oraclejdk8
-  - openjdk8
   - openjdk11
 matrix:
 before_cache:

--- a/build.jenkins
+++ b/build.jenkins
@@ -4,7 +4,7 @@
     stages {
         stage('Build') {
             agent {
-                docker { image 'govukverify/java8:latest' }
+                docker { image 'openjdk:11-jdk' }
             }
             steps {
                 sh './gradlew clean build'
@@ -27,7 +27,7 @@
         stage('Publish') {
             when { branch 'master' }
             agent {
-                docker { image 'govukverify/java8:latest' }
+                docker { image 'openjdk:11-jdk' }
             }
             environment {
                 // Artifactory credentials


### PR DESCRIPTION
`verify-saml-libs` is a library used in various Verify projects, like Hub and Proxy Node. We are migrating our Verify java runtimes off java8 and onto java11, for security reasons.

We want to build `verify-saml-libs` on OpenJDK 11 to mitigate any compile time vulnerabilities, and standardise to this java version.

To review:
* consider that the Jenkinsfile  `build.jenkins` now uses the Docker image `openjdk:11-jdk` to build the library, instead of `govukverify/java8:latest`.
* check the build completes successfully in Jenkins.