### PR TITLE
ensure verify-saml-libs can be used by java 8 clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
   - openjdk11
+  - openjdk8
+  - oraclejdk8
 matrix:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,15 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
+    configurations.all {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     ext {
         opensaml_version = "3.4.2"
         dropwizard_version = "1.3.9"
-        ida_utils_version = '359'
+        ida_utils_version = '360'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }


### PR DESCRIPTION
A project possibly compiled with java 1.8 (i.e. the `verify-matching-service-adapter`) will need to use `verify-saml-libs` compiled against java 1.8.

If not, the compiler will fail with a message like "class file has wrong version 55.0, should be 52.0".

This PR compiles `verify-saml-libs` using Java 1.8, and depends on  latest [verify-utils-libs](https://github.com/alphagov/verify-utils-libs/pull/34), also compiled using Java 1.8. 

To test, publish this branch to local maven repository, using `./gradlew clean publishToMavenLocal`.
Then, using the snapshot local version of verify-saml-libs published above run `./pre-commit.sh` on projects:

- verify-hub using openjdk-11
- verify-proxy-node using openjdk-11
- verify-matching-service-adapter using jdk 1.8

Then run verify-matching-service-adapter using jdk 1.8 using version `188` of verify-saml-libs, and the compile error should surface. Version 188 is compiled using openjdk-11.

this PR can be reverted when all clients of `verify-matching-service-adapter` are using openjdk-11. 

