### PR TITLE
EID-1504 Allow eIDAS assertions to be unsigned

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -41,7 +41,7 @@ public class AssertionValidator {
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
         validateSignaturePresent(signature, assertion);
-        validateCommon(assertion, requestId, expectedRecipientId);
+        validateAssertonProperties(assertion, requestId, expectedRecipientId);
     }
 
     public void validateEidas(
@@ -51,10 +51,10 @@ public class AssertionValidator {
 
         Signature signature = assertion.getSignature();
         if (signature != null) validateSignaturePresent(signature, assertion);
-        validateCommon(assertion, requestId, expectedRecipientId);
+        validateAssertonProperties(assertion, requestId, expectedRecipientId);
     }
 
-    private void validateCommon(
+    private void validateAssertonProperties(
             Assertion assertion,
             String requestId,
             String expectedRecipientId) {

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -34,17 +34,25 @@ public class AssertionValidator {
             Assertion assertion,
             String requestId,
             String expectedRecipientId) {
+        validate(assertion, requestId, expectedRecipientId, false);
+    }
+
+    public void validate(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId,
+            boolean isEidasAssertion) {
 
         Signature signature = assertion.getSignature();
         if (assertion.getID() == null) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
-        if (signature == null) {
+        if (signature == null && !isEidasAssertion) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSignatureMissing(assertion.getID());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
-        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+        if (signature != null && !SamlSignatureUtil.isSignaturePresent(signature)) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
@@ -20,14 +20,26 @@ public class SamlAssertionsSignatureValidator {
     public ValidatedAssertions validate(List<Assertion> assertions, QName role) {
         for (Assertion assertion : assertions) {
             final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validate(assertion, role);
-            if(!samlValidationResponse.isOK()) {
-                SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
-                if (samlValidationResponse.getCause() != null)
-                    throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
-                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-            }
+            checkResponseisOk(samlValidationResponse);
         }
         return new ValidatedAssertions(assertions);
+    }
+
+    public ValidatedAssertions validateEidas(List<Assertion> assertions, QName role) {
+        for (Assertion assertion : assertions) {
+            final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validateEidasAssertion(assertion, role);
+            checkResponseisOk(samlValidationResponse);
+        }
+        return new ValidatedAssertions(assertions);
+    }
+
+    private void checkResponseisOk(SamlValidationResponse samlValidationResponse) {
+        if(!samlValidationResponse.isOK()) {
+            SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
+            if (samlValidationResponse.getCause() != null)
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
     }
 
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
@@ -22,36 +22,29 @@ public class SamlMessageSignatureValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SamlMessageSignatureValidator.class);
     private final SignatureValidator signatureValidator;
-    private final boolean isEidasAssertion;
 
 
     public SamlMessageSignatureValidator(SignatureValidator signatureValidator) {
         this.signatureValidator = signatureValidator;
-        this.isEidasAssertion = false;
-    }
-
-    public SamlMessageSignatureValidator(SignatureValidator signatureValidator, boolean isEidasAssertion) {
-        this.signatureValidator = signatureValidator;
-        this.isEidasAssertion = isEidasAssertion;
     }
 
     public SamlValidationResponse validate(Response response, QName role) {
         Issuer issuer = response.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(response, issuer, role);
+        SamlValidationResponse issuerResponse = validateIssuer(issuer);
         if (issuerResponse != null) return issuerResponse;
         return validateSignature(response, issuer.getValue(), role);
     }
 
     public SamlValidationResponse validate(Assertion assertion, QName role) {
         Issuer issuer = assertion.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(assertion, issuer, role);
+        SamlValidationResponse issuerResponse = validateIssuer(issuer);
         if (issuerResponse != null) return issuerResponse;
         return validateSignature(assertion, issuer.getValue(), role);
     }
 
     public SamlValidationResponse validateEidasAssertion(Assertion assertion, QName role) {
         Issuer issuer = assertion.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(assertion, issuer, role);
+        SamlValidationResponse issuerResponse = validateIssuer(issuer);
         if (issuerResponse != null) return issuerResponse;
 
         if (assertion.getSignature() == null) return SamlValidationResponse.aValidResponse();
@@ -64,12 +57,12 @@ public class SamlMessageSignatureValidator {
      */
     public SamlValidationResponse validate(RequestAbstractType request, QName role) {
         Issuer issuer = request.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(request, issuer, role);
+        SamlValidationResponse issuerResponse = validateIssuer(issuer);
         if (issuerResponse != null) return issuerResponse;
         return validateSignature(request, issuer.getValue(), role);
     }
 
-    private SamlValidationResponse validateIssuer(SignableSAMLObject request, Issuer issuer, QName role) {
+    private SamlValidationResponse validateIssuer(Issuer issuer) {
         if (issuer == null) {
             return SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.missingIssuer());
         }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
@@ -15,6 +15,8 @@ import uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil;
 
 import javax.xml.namespace.QName;
 
+import java.util.Optional;
+
 import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.invalidMessageSignature;
 import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.unableToValidateMessageSignature;
 
@@ -30,22 +32,22 @@ public class SamlMessageSignatureValidator {
 
     public SamlValidationResponse validate(Response response, QName role) {
         Issuer issuer = response.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(issuer);
-        if (issuerResponse != null) return issuerResponse;
+        Optional<SamlValidationResponse> issuerResponse = validateIssuer(issuer);
+        if (issuerResponse.isPresent()) return issuerResponse.get();
         return validateSignature(response, issuer.getValue(), role);
     }
 
     public SamlValidationResponse validate(Assertion assertion, QName role) {
         Issuer issuer = assertion.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(issuer);
-        if (issuerResponse != null) return issuerResponse;
+        Optional<SamlValidationResponse> issuerResponse = validateIssuer(issuer);
+        if (issuerResponse.isPresent()) return issuerResponse.get();
         return validateSignature(assertion, issuer.getValue(), role);
     }
 
     public SamlValidationResponse validateEidasAssertion(Assertion assertion, QName role) {
         Issuer issuer = assertion.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(issuer);
-        if (issuerResponse != null) return issuerResponse;
+        Optional<SamlValidationResponse> issuerResponse = validateIssuer(issuer);
+        if (issuerResponse.isPresent()) return issuerResponse.get();
 
         if (assertion.getSignature() == null) return SamlValidationResponse.aValidResponse();
         return validateSignature(assertion, issuer.getValue(), role);
@@ -57,19 +59,19 @@ public class SamlMessageSignatureValidator {
      */
     public SamlValidationResponse validate(RequestAbstractType request, QName role) {
         Issuer issuer = request.getIssuer();
-        SamlValidationResponse issuerResponse = validateIssuer(issuer);
-        if (issuerResponse != null) return issuerResponse;
+        Optional<SamlValidationResponse> issuerResponse = validateIssuer(issuer);
+        if (issuerResponse.isPresent()) return issuerResponse.get();
         return validateSignature(request, issuer.getValue(), role);
     }
 
-    private SamlValidationResponse validateIssuer(Issuer issuer) {
+    private Optional<SamlValidationResponse> validateIssuer(Issuer issuer) {
         if (issuer == null) {
-            return SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.missingIssuer());
+            return Optional.of(SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.missingIssuer()));
         }
         if (Strings.isNullOrEmpty(issuer.getValue())) {
-            return SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.emptyIssuer());
+            return Optional.of(SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.emptyIssuer()));
         }
-        return null;
+        return Optional.empty();
     }
 
     private SamlValidationResponse validateSignature(SignableSAMLObject signableSAMLObject, String issuerId, QName role) {

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlMessageSignatureValidator.java
@@ -22,10 +22,17 @@ public class SamlMessageSignatureValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SamlMessageSignatureValidator.class);
     private final SignatureValidator signatureValidator;
+    private final boolean isEidasAssertion;
 
 
     public SamlMessageSignatureValidator(SignatureValidator signatureValidator) {
         this.signatureValidator = signatureValidator;
+        this.isEidasAssertion = false;
+    }
+
+    public SamlMessageSignatureValidator(SignatureValidator signatureValidator, boolean isEidasAssertion) {
+        this.signatureValidator = signatureValidator;
+        this.isEidasAssertion = isEidasAssertion;
     }
 
     public SamlValidationResponse validate(Response response, QName role) {
@@ -57,7 +64,9 @@ public class SamlMessageSignatureValidator {
 
     private SamlValidationResponse validateWithIssuer(SignableSAMLObject signableSAMLObject, String issuerId, QName role) {
         if (signableSAMLObject.getSignature() == null){
-            return SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.missingSignature());
+            return isEidasAssertion ?
+                SamlValidationResponse.aValidResponse() :
+                SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.missingSignature());
         }
         if (!SamlSignatureUtil.isSignaturePresent(signableSAMLObject.getSignature())) {
             return SamlValidationResponse.anInvalidResponse(SamlTransformationErrorFactory.signatureNotSigned());

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -43,7 +43,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateSubjectValidation() throws Exception {
+    public void validateShouldDelegateSubjectValidation() {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -55,7 +55,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+    public void validateShouldDelegateSubjectConfirmationValidation() {
         String requestId = UUID.randomUUID().toString();
         SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
         Assertion assertion = anAssertion()
@@ -68,7 +68,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateAttributeValidation() throws Exception {
+    public void validateShouldDelegateAttributeValidation() {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -80,7 +80,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
+    public void validateShouldThrowExceptionIfAnyAssertionDoesNotContainASignature() {
         String someID = UUID.randomUUID().toString();
         Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
 
@@ -88,7 +88,15 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
+    public void validateShouldAllowAnEidasAssertionToNotContainASignature() {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
+
+        validator.validate(assertion, "", assertion.getID(), true);
+    }
+
+    @Test
+    public void validateShouldThrowExceptionIfAnAssertionIsNotSigned() {
         String someID = UUID.randomUUID().toString();
 
         Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
@@ -97,35 +105,35 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDoNothingIfAllAssertionsAreSigned() throws Exception {
+    public void validateShouldDoNothingIfAllAssertionsAreSigned() {
         Assertion assertion = anAssertion().buildUnencrypted();
 
         validator.validate(assertion, "", assertion.getID());
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIdIsMissing() {
         Assertion assertion = anAssertion().withId(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfVersionIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsMissing() {
         Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsNotSamlTwoPointZero() {
         Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIssueInstantIsMissing() {
         Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -10,6 +10,7 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.core.validation.assertion.AssertionValidator;
@@ -18,6 +19,7 @@ import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
 import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
@@ -88,11 +90,19 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldAllowAnEidasAssertionToNotContainASignature() {
+    public void validateEidasShouldAllowAnEidasAssertionToNotContainASignature() {
         String someID = UUID.randomUUID().toString();
         Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
 
-        validator.validate(assertion, "", assertion.getID(), true);
+        validator.validateEidas(assertion, "", assertion.getID());
+    }
+
+    @Test
+    public void validateEidasShouldValidateSignaturePresentIfSignatureExists() {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
+
+        assertThrows(SamlTransformationErrorException.class, () -> validator.validateEidas(assertion, "", assertion.getID()));
     }
 
     @Test

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
@@ -52,6 +52,18 @@ public class SamlAssertionsSignatureValidatorTest {
         verify(samlMessageSignatureValidator).validate(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
+    @Test
+    public void shouldValidateEidasAssertionsWithAndWithoutSignature() {
+        final Assertion assertion1 = AssertionBuilder.anAssertion().withSignature(null).build();
+        final Assertion assertion2 = AssertionBuilder.anAssertion().build();
+        final List<Assertion> assertions = asList(assertion1, assertion2);
+
+        samlAssertionsSignatureValidator.validateEidas(assertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion1, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldFailOnFirstBadlySignedAssertion() {
         final Assertion assertion1 = AssertionBuilder.anAssertion().withoutSigning().build();

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -45,7 +45,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldAcceptUnsignedAssertionsFromEidasCountries() {
+    public void validateEidasAssertionShouldAcceptUnsignedAssertionsFromEidasCountries() {
         final Assertion unsignedAssertion = anAssertion()
             .withIssuer(anIssuer().withIssuerId(issuerId).build())
             .withSignature(null)
@@ -53,7 +53,7 @@ public class SamlMessageSignatureValidatorTest {
 
         SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator, true);
 
-        SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validate(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validateEidasAssertion(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         assertThat(signatureValidationResponse.isOK()).isTrue();
     }

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -51,7 +51,7 @@ public class SamlMessageSignatureValidatorTest {
             .withSignature(null)
             .build();
 
-        SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator, true);
+        SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
 
         SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validateEidasAssertion(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -32,7 +32,7 @@ public class SamlMessageSignatureValidatorTest {
     private final SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsMissing() {
+    public void validateShouldReturnBadResponseIfRequestSignatureIsMissing() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSignatureElement()
@@ -45,7 +45,21 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestIsNotSigned() {
+    public void validateShouldAcceptUnsignedAssertionsFromEidasCountries() {
+        final Assertion unsignedAssertion = anAssertion()
+            .withIssuer(anIssuer().withIssuerId(issuerId).build())
+            .withSignature(null)
+            .build();
+
+        SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator, true);
+
+        SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validate(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        assertThat(signatureValidationResponse.isOK()).isTrue();
+    }
+
+    @Test
+    public void validateShouldReturnBadResponseIfRequestIsNotSigned() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSigning()
@@ -58,7 +72,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsBad() {
+    public void validateShouldReturnBadResponseIfRequestSignatureIsBad() {
         Credential badCredential = new TestCredentialFactory(TestCertificateStrings.UNCHAINED_PUBLIC_CERT, TestCertificateStrings.UNCHAINED_PRIVATE_KEY).getSigningCredential();
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
@@ -72,7 +86,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAuthnRequest() {
+    public void validateShouldAcceptSignedAuthnRequest() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAuthnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -81,7 +95,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAssertion() {
+    public void validateShouldAcceptSignedAssertion() {
         final Assertion signedAssertion = anAssertion().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAssertion, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -90,7 +104,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAttributeQuery() {
+    public void validateShouldAcceptSignedAttributeQuery() {
         final AttributeQuery signedAttributeQuery = AttributeQueryBuilder.anAttributeQuery().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAttributeQuery, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -99,7 +113,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedResponse() throws Exception {
+    public void validateShouldAcceptSignedResponse() throws Exception {
         final Response signedResponse = ResponseBuilder.aResponse().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedResponse, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -108,7 +122,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldReturnBadResponseIfIssuerIsMissing() {
+    public void validateShouldReturnBadResponseIfIssuerIsMissing() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(null)
                 .build();
@@ -120,7 +134,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldReturnBadResponseIfIssuerIsEmpty() {
+    public void validateShouldReturnBadResponseIfIssuerIsEmpty() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId("").build())
                 .build();


### PR DESCRIPTION
The eIDAS SAML profile does not require that attributes are signed. This
is different to the Verify profile which does require they are signed.

We will soon be onboarding a European country, Spain, that does not sign
its assertions. This will break saml-engine as well as the MSA.

This updates the `SamlMessageSignatureValidator` to make it possible to
skip signature validation if the message being validated is an eIDAS
attribute (determined by a flag when the validator is instantiated in
the apps).

If the attribute is signed (most countries do) we still validate that
signature and will raise if it fails - so we don't start allowing
invalid signatures. If the signature is not provided however, and the
flag is set, we just skip the validation.