### PR TITLE
BAU Upgrade dropwizard to 1.3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
 
     ext {
         opensaml_version = "3.4.2"
-        dropwizard_version = "1.3.9"
+        dropwizard_version = "1.3.12"
         ida_utils_version = '360'
         trust_anchor_version = '1.0-56'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"


### PR DESCRIPTION
A few vulnerabilities were found in 1.3.9 which were affecting downstream
projects (hub).

[CVE-2019-10247](https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174560)
[CVE-2019-12086](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736)