### PR TITLE
Bau - Fix broken saml-lib jenkins job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,6 @@ allprojects {
     apply plugin: 'jacoco'
 }
 
-repositories {
-    jcenter()
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'

--- a/saml-lib/src/test/java/uk/gov/ida/saml/hub/factories/AttributeFactory_1_1Test.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/hub/factories/AttributeFactory_1_1Test.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.jodatime.api.Assertions.assertThat;
 
 @RunWith(OpenSAMLMockitoRunner.class)
 public class AttributeFactory_1_1Test {


### PR DESCRIPTION
- Remove the unused jcentre from gradle
- Add back the import static org.assertj.jodatime.api.Assertions.assertThat which is being used

To fix https://verify-ci.ida.digital.cabinet-office.gov.uk/job/alphagov/job/verify-saml-libs/job/master/