### PR TITLE
BAU: Add config to run tests from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.9 as clone
+
+RUN apk --update add --no-cache git
+RUN git clone --depth=1 https://github.com/alphagov/verify-saml-libs.git && \
+    rm -rf verify-saml-libs/.git
+
+FROM gradle:jdk11
+
+COPY --from=clone /verify-saml-libs/ /verify-saml-libs/
+WORKDIR /verify-saml-libs/
+
+CMD [ "./pre-commit.sh" ]

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+function be_in_directory {
+    cd "$( dirname "${BASH_SOURCE[0]}" )"
+}
+
+be_in_directory
+docker build -t verify-saml-libs .
+docker run --rm -it verify-saml-libs "$@"


### PR DESCRIPTION
Keep running the tests in a Docker container. In theory this provides a starting point for doing more work in Docker in the future if wanted.