### PR TITLE
ZD-3570817 duplicate matching datasets

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/GenericHubProfileValidationSpecification.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/GenericHubProfileValidationSpecification.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.core.validation.errors;
 
+import org.slf4j.event.Level;
 import uk.gov.ida.saml.core.validation.SamlDocumentReference;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 
@@ -84,6 +85,10 @@ public class GenericHubProfileValidationSpecification extends SamlValidationSpec
 
     public GenericHubProfileValidationSpecification(String errorFormat, Object... params) {
         super(MessageFormat.format(errorFormat, params), true);
+    }
+
+    public GenericHubProfileValidationSpecification(Level level, String errorFormat, Object... params) {
+        super(MessageFormat.format(errorFormat, params), true, level);
     }
 
     @Override

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
@@ -17,6 +17,7 @@ import uk.gov.ida.saml.core.validation.errors.SamlValidationSpecification;
 
 import javax.xml.namespace.QName;
 import java.net.URI;
+import org.slf4j.event.Level;
 
 import static uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification.ATTRIBUTE_STATEMENT_EMPTY;
 
@@ -178,7 +179,7 @@ public final class SamlTransformationErrorFactory {
     }
 
     public static SamlValidationSpecificationFailure duplicateMatchingDataset(final String id, final String responseIssuerId) {
-        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.DUPLICATE_MATCHING_DATASET, id, responseIssuerId);
+        return new GenericHubProfileValidationSpecification(Level.WARN, GenericHubProfileValidationSpecification.DUPLICATE_MATCHING_DATASET, id, responseIssuerId);
     }
 
     public static SamlValidationSpecificationFailure mdsStatementMissing() {

--- a/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/ElementToOpenSamlXMLObjectTransformer.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/ElementToOpenSamlXMLObjectTransformer.java
@@ -9,7 +9,7 @@ import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 
 import java.util.function.Function;
 
-import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.unableToUnmarshallElementToOpenSaml;
+import static uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory.unableToUnmarshallElementToOpenSaml;
 
 public class ElementToOpenSamlXMLObjectTransformer<TOutput extends XMLObject> implements Function<Element,TOutput> {
     private final SamlObjectParser samlObjectParser;

--- a/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/OpenSamlXMLObjectUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/OpenSamlXMLObjectUnmarshaller.java
@@ -7,7 +7,7 @@ import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 
-import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.unableToDeserializeStringToOpenSaml;
+import static uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory.unableToDeserializeStringToOpenSaml;
 
 public class OpenSamlXMLObjectUnmarshaller<TOutput extends XMLObject> {
 

--- a/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoder.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoder.java
@@ -6,7 +6,7 @@ import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 
 import static java.util.regex.Pattern.matches;
-import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
+import static uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
 
 public class Base64StringDecoder {
 

--- a/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/NotNullSamlStringValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/NotNullSamlStringValidator.java
@@ -2,7 +2,7 @@ package uk.gov.ida.saml.deserializers.validators;
 
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.saml.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory;
 
 public class NotNullSamlStringValidator {
     public void validate(String input) {

--- a/saml-lib/src/main/java/uk/gov/ida/saml/errors/SamlTransformationErrorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/errors/SamlTransformationErrorFactory.java
@@ -1,7 +1,6 @@
-package uk.gov.ida.saml.errors;
+package uk.gov.ida.saml.core.validation.errors;
 
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.saml.core.validation.errors.SamlValidationSpecification;
 
 public final class SamlTransformationErrorFactory {
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
@@ -16,7 +16,7 @@ public class SamlTransformationErrorFactoryTest {
 
     }
     @Test // arbitrary choice of error
-    public void shouldHaveLevelErrorFormissingIssueInstant() {
+    public void shouldHaveLevelErrorForMissingIssueInstant() {
         SamlValidationSpecificationFailure failure =
                 SamlTransformationErrorFactory.missingIssueInstant("id");
         assertThat(failure.getLogLevel()).isEqualTo(Level.ERROR);

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.core.validation.errors;
+
+import org.junit.Test;
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SamlTransformationErrorFactoryTest {
+    @Test
+    public void shouldHaveLevelWarnForDuplicateMatchingDataset() {
+        SamlValidationSpecificationFailure failure =
+                SamlTransformationErrorFactory.duplicateMatchingDataset("id", "responseIssuerId");
+        assertThat(failure.getLogLevel()).isEqualTo(Level.WARN);
+
+    }
+    @Test // arbitrary choice of error
+    public void shouldHaveLevelErrorFormissingIssueInstant() {
+        SamlValidationSpecificationFailure failure =
+                SamlTransformationErrorFactory.missingIssueInstant("id");
+        assertThat(failure.getLogLevel()).isEqualTo(Level.ERROR);
+
+    }
+
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/deserializers/validators/Base64StringDecoderTest.java
@@ -10,7 +10,7 @@ import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static uk.gov.ida.saml.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
+import static uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory.invalidBase64Encoding;
 
 @RunWith(MockitoJUnitRunner.class)
 public class Base64StringDecoderTest {


### PR DESCRIPTION
Once every few months someone somewhere clicks the back button really quickly and generates an error in our logs; it's not really a problem and should probably be logged under WARN instead of ERROR.

Provide additional constructor for GenericHubProfileValidationSpecification that allows a Level to specified.

Use that constructor in uk.gov.ida.saml.core.validation.errors.SamlTransformationErrorFactory.duplicateMatchingDataset so that the Level is indeed WARN.

Write a test to make sure it happens.  Write a test for an arbitrary method to make sure it only happens for duplicateMatchingDataset.

Because the package names are out of sync with the folder structure, a lot of imports have changed thanks to the IDE.  Everything appears to still work despite this.