### PR TITLE
AUTO-112: Update Wiremock library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
         test_deps "uk.gov.ida:common-test-utils:2.0.0-46",
-                "com.github.tomakehurst:wiremock-standalone:2.16.0",
+                "com.github.tomakehurst:wiremock-standalone:2.23.2",
                 "io.dropwizard:dropwizard-testing:$dropwizard_version",
                 'org.hamcrest:hamcrest-library:1.3',
                 'org.assertj:assertj-joda-time:1.1.0',


### PR DESCRIPTION
This change updates Wiremock library to use latest version. This change is needed for resolving Verify Test RP's integration test failures caused by Wiremock issues.

Author: @adityapahuja