### PR TITLE
update request ids for new validations, as used in verify-proxy-node

### DIFF
--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
@@ -30,8 +30,8 @@ public class ResponseBuilder {
 
     private static TestSamlObjectFactory testSamlObjectFactory = new TestSamlObjectFactory();
 
-    public static final String DEFAULT_REQUEST_ID = "default-request-id";
-    public static final String DEFAULT_RESPONSE_ID = "default-response-id";
+    public static final String DEFAULT_REQUEST_ID = "_default-request-id_min-20-chars";
+    public static final String DEFAULT_RESPONSE_ID = "_default-response-id_min-20-chars";
 
     private EncryptedAssertion defaultEncryptedAssertion;
     private boolean addDefaultEncryptedAssertionIfNoneIsAdded = true;

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseBuilder.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseBuilder.java
@@ -32,8 +32,8 @@ public class ResponseBuilder {
 
     private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
 
-    public static final String DEFAULT_REQUEST_ID = "default-request-id";
-    public static final String DEFAULT_RESPONSE_ID = "default-response-id";
+    public static final String DEFAULT_REQUEST_ID = "_default-request-id_min-20-chars";
+    public static final String DEFAULT_RESPONSE_ID = "_default-response-id_min-20-chars";
 
     private EncryptedAssertion defaultEncryptedAssertion;
     private boolean addDefaultEncryptedAssertionIfNoneIsAdded = true;


### PR DESCRIPTION
New validations for request ids in verify-proxy-node require a minimum of 20 characters to be compliant with XML/SAML Ids.