### PR TITLE
Revert "EID-1504 Allow eIDAS assertions to be unsigned"

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -36,31 +36,16 @@ public class AssertionValidator {
             String expectedRecipientId) {
 
         Signature signature = assertion.getSignature();
+        if (assertion.getID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
         if (signature == null) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSignatureMissing(assertion.getID());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
-        validateSignaturePresent(signature, assertion);
-        validateAssertonProperties(assertion, requestId, expectedRecipientId);
-    }
-
-    public void validateEidas(
-            Assertion assertion,
-            String requestId,
-            String expectedRecipientId) {
-
-        Signature signature = assertion.getSignature();
-        if (signature != null) validateSignaturePresent(signature, assertion);
-        validateAssertonProperties(assertion, requestId, expectedRecipientId);
-    }
-
-    private void validateAssertonProperties(
-            Assertion assertion,
-            String requestId,
-            String expectedRecipientId) {
-
-        if (assertion.getID() == null) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
+        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
         if (assertion.getIssueInstant() == null) {
@@ -81,13 +66,6 @@ public class AssertionValidator {
 
         validateSubject(assertion, requestId, expectedRecipientId);
         basicAssertionSubjectConfirmationValidator.validate(assertion.getSubject().getSubjectConfirmations().get(0));
-    }
-
-    private void validateSignaturePresent(Signature signature, Assertion assertion) {
-        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
     }
 
     protected void validateSubject(

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
@@ -20,26 +20,14 @@ public class SamlAssertionsSignatureValidator {
     public ValidatedAssertions validate(List<Assertion> assertions, QName role) {
         for (Assertion assertion : assertions) {
             final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validate(assertion, role);
-            checkResponseisOk(samlValidationResponse);
+            if(!samlValidationResponse.isOK()) {
+                SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
+                if (samlValidationResponse.getCause() != null)
+                    throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+            }
         }
         return new ValidatedAssertions(assertions);
-    }
-
-    public ValidatedAssertions validateEidas(List<Assertion> assertions, QName role) {
-        for (Assertion assertion : assertions) {
-            final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validateEidasAssertion(assertion, role);
-            checkResponseisOk(samlValidationResponse);
-        }
-        return new ValidatedAssertions(assertions);
-    }
-
-    private void checkResponseisOk(SamlValidationResponse samlValidationResponse) {
-        if(!samlValidationResponse.isOK()) {
-            SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
-            if (samlValidationResponse.getCause() != null)
-                throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
     }
 
 }

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -10,7 +10,6 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
-import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.core.validation.assertion.AssertionValidator;
@@ -19,7 +18,6 @@ import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
 import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
@@ -45,7 +43,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateSubjectValidation() {
+    public void validate_shouldDelegateSubjectValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -57,7 +55,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateSubjectConfirmationValidation() {
+    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
         Assertion assertion = anAssertion()
@@ -70,7 +68,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateAttributeValidation() {
+    public void validate_shouldDelegateAttributeValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -82,7 +80,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldThrowExceptionIfAnyAssertionDoesNotContainASignature() {
+    public void validate_shouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
         String someID = UUID.randomUUID().toString();
         Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
 
@@ -90,23 +88,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateEidasShouldAllowAnEidasAssertionToNotContainASignature() {
-        String someID = UUID.randomUUID().toString();
-        Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
-
-        validator.validateEidas(assertion, "", assertion.getID());
-    }
-
-    @Test
-    public void validateEidasShouldValidateSignaturePresentIfSignatureExists() {
-        String someID = UUID.randomUUID().toString();
-        Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
-
-        assertThrows(SamlTransformationErrorException.class, () -> validator.validateEidas(assertion, "", assertion.getID()));
-    }
-
-    @Test
-    public void validateShouldThrowExceptionIfAnAssertionIsNotSigned() {
+    public void validate_shouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
         String someID = UUID.randomUUID().toString();
 
         Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
@@ -115,35 +97,35 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDoNothingIfAllAssertionsAreSigned() {
+    public void validate_shouldDoNothingIfAllAssertionsAreSigned() throws Exception {
         Assertion assertion = anAssertion().buildUnencrypted();
 
         validator.validate(assertion, "", assertion.getID());
     }
 
     @Test
-    public void validateShouldThrowExceptionIfIdIsMissing() {
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
         Assertion assertion = anAssertion().withId(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
     }
 
     @Test
-    public void validateShouldThrowExceptionIfVersionIsMissing() {
+    public void validate_shouldThrowExceptionIfVersionIsMissing() throws Exception {
         Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
     }
 
     @Test
-    public void validateShouldThrowExceptionIfVersionIsNotSamlTwoPointZero() {
+    public void validate_shouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
         Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
     }
 
     @Test
-    public void validateShouldThrowExceptionIfIssueInstantIsMissing() {
+    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
         Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -43,7 +43,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateSubjectValidation() throws Exception {
+    public void validateShouldDelegateSubjectValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -55,7 +55,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+    public void validateShouldDelegateSubjectConfirmationValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
         Assertion assertion = anAssertion()
@@ -68,7 +68,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDelegateAttributeValidation() throws Exception {
+    public void validateShouldDelegateAttributeValidation() throws Exception {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -80,7 +80,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
+    public void validateShouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
         String someID = UUID.randomUUID().toString();
         Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
 
@@ -88,7 +88,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
+    public void validateShouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
         String someID = UUID.randomUUID().toString();
 
         Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
@@ -97,35 +97,35 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validate_shouldDoNothingIfAllAssertionsAreSigned() throws Exception {
+    public void validateShouldDoNothingIfAllAssertionsAreSigned() throws Exception {
         Assertion assertion = anAssertion().buildUnencrypted();
 
         validator.validate(assertion, "", assertion.getID());
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIdIsMissing() throws Exception {
         Assertion assertion = anAssertion().withId(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfVersionIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsMissing() throws Exception {
         Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
         Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
     }
 
     @Test
-    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
         Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
@@ -52,18 +52,6 @@ public class SamlAssertionsSignatureValidatorTest {
         verify(samlMessageSignatureValidator).validate(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
-    @Test
-    public void shouldValidateEidasAssertionsWithAndWithoutSignature() {
-        final Assertion assertion1 = AssertionBuilder.anAssertion().withSignature(null).build();
-        final Assertion assertion2 = AssertionBuilder.anAssertion().build();
-        final List<Assertion> assertions = asList(assertion1, assertion2);
-
-        samlAssertionsSignatureValidator.validateEidas(assertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-
-        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion1, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-    }
-
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldFailOnFirstBadlySignedAssertion() {
         final Assertion assertion1 = AssertionBuilder.anAssertion().withoutSigning().build();

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -32,7 +32,7 @@ public class SamlMessageSignatureValidatorTest {
     private final SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
 
     @Test
-    public void validateShouldReturnBadResponseIfRequestSignatureIsMissing() {
+    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsMissing() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSignatureElement()
@@ -45,21 +45,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateEidasAssertionShouldAcceptUnsignedAssertionsFromEidasCountries() {
-        final Assertion unsignedAssertion = anAssertion()
-            .withIssuer(anIssuer().withIssuerId(issuerId).build())
-            .withSignature(null)
-            .build();
-
-        SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
-
-        SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validateEidasAssertion(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
-
-        assertThat(signatureValidationResponse.isOK()).isTrue();
-    }
-
-    @Test
-    public void validateShouldReturnBadResponseIfRequestIsNotSigned() {
+    public void validateWithIssue_shouldReturnBadResponseIfRequestIsNotSigned() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSigning()
@@ -72,7 +58,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldReturnBadResponseIfRequestSignatureIsBad() {
+    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsBad() {
         Credential badCredential = new TestCredentialFactory(TestCertificateStrings.UNCHAINED_PUBLIC_CERT, TestCertificateStrings.UNCHAINED_PRIVATE_KEY).getSigningCredential();
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
@@ -86,7 +72,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldAcceptSignedAuthnRequest() {
+    public void validate_shouldAcceptSignedAuthnRequest() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAuthnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -95,7 +81,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldAcceptSignedAssertion() {
+    public void validate_shouldAcceptSignedAssertion() {
         final Assertion signedAssertion = anAssertion().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAssertion, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -104,7 +90,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldAcceptSignedAttributeQuery() {
+    public void validate_shouldAcceptSignedAttributeQuery() {
         final AttributeQuery signedAttributeQuery = AttributeQueryBuilder.anAttributeQuery().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAttributeQuery, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -113,7 +99,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldAcceptSignedResponse() throws Exception {
+    public void validate_shouldAcceptSignedResponse() throws Exception {
         final Response signedResponse = ResponseBuilder.aResponse().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedResponse, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -122,7 +108,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldReturnBadResponseIfIssuerIsMissing() {
+    public void validate_shouldReturnBadResponseIfIssuerIsMissing() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(null)
                 .build();
@@ -134,7 +120,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateShouldReturnBadResponseIfIssuerIsEmpty() {
+    public void validate_shouldReturnBadResponseIfIssuerIsEmpty() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId("").build())
                 .build();

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -32,7 +32,7 @@ public class SamlMessageSignatureValidatorTest {
     private final SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsMissing() {
+    public void validateWithIssueShouldReturnBadResponseIfRequestSignatureIsMissing() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSignatureElement()
@@ -45,7 +45,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestIsNotSigned() {
+    public void validateWithIssueShouldReturnBadResponseIfRequestIsNotSigned() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSigning()
@@ -58,7 +58,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssue_shouldReturnBadResponseIfRequestSignatureIsBad() {
+    public void validateWithIssueShouldReturnBadResponseIfRequestSignatureIsBad() {
         Credential badCredential = new TestCredentialFactory(TestCertificateStrings.UNCHAINED_PUBLIC_CERT, TestCertificateStrings.UNCHAINED_PRIVATE_KEY).getSigningCredential();
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
@@ -72,7 +72,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAuthnRequest() {
+    public void validateShouldAcceptSignedAuthnRequest() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAuthnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -81,7 +81,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAssertion() {
+    public void validateShouldAcceptSignedAssertion() {
         final Assertion signedAssertion = anAssertion().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAssertion, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -90,7 +90,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedAttributeQuery() {
+    public void validateShouldAcceptSignedAttributeQuery() {
         final AttributeQuery signedAttributeQuery = AttributeQueryBuilder.anAttributeQuery().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedAttributeQuery, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -99,7 +99,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldAcceptSignedResponse() throws Exception {
+    public void validateShouldAcceptSignedResponse() throws Exception {
         final Response signedResponse = ResponseBuilder.aResponse().build();
 
         SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(signedResponse, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
@@ -108,7 +108,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldReturnBadResponseIfIssuerIsMissing() {
+    public void validateShouldReturnBadResponseIfIssuerIsMissing() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(null)
                 .build();
@@ -120,7 +120,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validate_shouldReturnBadResponseIfIssuerIsEmpty() {
+    public void validateShouldReturnBadResponseIfIssuerIsEmpty() {
         final AuthnRequest signedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId("").build())
                 .build();


### PR DESCRIPTION
This reverts all the commits included in [PR #64](https://github.com/alphagov/verify-saml-libs/pull/64).
These files have not been altered in anyway since that PR so this
reversion doesn't affect other work.

This is being done due to a security issue with the approach and a new
implementation is being worked on.