### PR TITLE
EID-1608 Check if assertions are unsigned

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -3,9 +3,9 @@ package uk.gov.ida.saml.core.validation.assertion;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.validation.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
 import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
 import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
@@ -28,6 +28,10 @@ public class AssertionValidator {
         this.subjectValidator = subjectValidator;
         this.assertionAttributeStatementValidator = assertionAttributeStatementValidator;
         this.basicAssertionSubjectConfirmationValidator = basicAssertionSubjectConfirmationValidator;
+    }
+
+    public boolean isAssertionUnsigned(Assertion assertion) {
+        return assertion.getSignature() == null;
     }
 
     public void validate(


### PR DESCRIPTION
EID-1608 requires us to make the original SAML from the country available if the assertions are unsigned.  To determine whether an assertion is unsigned we can use the code that already exists in verify-saml-libs if we expose that functionality via a new public method.

So that's what we've done - say hello to `isAssertionUnsigned(Assertion)` - it does what it says on the tin (if the tin is made of its signature and by use of getter naming convention).