### PR TITLE
Revert "EID-1583 Revert "EID-1504 Allow eIDAS assertions to be unsign…

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/assertion/AssertionValidator.java
@@ -40,16 +40,31 @@ public class AssertionValidator {
             String expectedRecipientId) {
 
         Signature signature = assertion.getSignature();
-        if (assertion.getID() == null) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
         if (signature == null) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSignatureMissing(assertion.getID());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
-        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
+        validateSignaturePresent(signature, assertion);
+        validateAssertonProperties(assertion, requestId, expectedRecipientId);
+    }
+
+    public void validateEidas(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        Signature signature = assertion.getSignature();
+        if (signature != null) validateSignaturePresent(signature, assertion);
+        validateAssertonProperties(assertion, requestId, expectedRecipientId);
+    }
+
+    private void validateAssertonProperties(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        if (assertion.getID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
         if (assertion.getIssueInstant() == null) {
@@ -70,6 +85,13 @@ public class AssertionValidator {
 
         validateSubject(assertion, requestId, expectedRecipientId);
         basicAssertionSubjectConfirmationValidator.validate(assertion.getSubject().getSubjectConfirmations().get(0));
+    }
+
+    private void validateSignaturePresent(Signature signature, Assertion assertion) {
+        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
     }
 
     protected void validateSubject(

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidator.java
@@ -20,14 +20,26 @@ public class SamlAssertionsSignatureValidator {
     public ValidatedAssertions validate(List<Assertion> assertions, QName role) {
         for (Assertion assertion : assertions) {
             final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validate(assertion, role);
-            if(!samlValidationResponse.isOK()) {
-                SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
-                if (samlValidationResponse.getCause() != null)
-                    throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
-                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-            }
+            checkResponseisOk(samlValidationResponse);
         }
         return new ValidatedAssertions(assertions);
+    }
+
+    public ValidatedAssertions validateEidas(List<Assertion> assertions, QName role) {
+        for (Assertion assertion : assertions) {
+            final SamlValidationResponse samlValidationResponse = samlMessageSignatureValidator.validateEidasAssertion(assertion, role);
+            checkResponseisOk(samlValidationResponse);
+        }
+        return new ValidatedAssertions(assertions);
+    }
+
+    private void checkResponseisOk(SamlValidationResponse samlValidationResponse) {
+        if(!samlValidationResponse.isOK()) {
+            SamlValidationSpecificationFailure failure = samlValidationResponse.getSamlValidationSpecificationFailure();
+            if (samlValidationResponse.getCause() != null)
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), samlValidationResponse.getCause(), failure.getLogLevel());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
     }
 
 }

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -10,6 +10,7 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.core.validation.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.core.validation.assertion.AssertionValidator;
@@ -18,6 +19,7 @@ import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
 import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
@@ -43,7 +45,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateSubjectValidation() throws Exception {
+    public void validateShouldDelegateSubjectValidation() {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -55,7 +57,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateSubjectConfirmationValidation() throws Exception {
+    public void validateShouldDelegateSubjectConfirmationValidation() {
         String requestId = UUID.randomUUID().toString();
         SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
         Assertion assertion = anAssertion()
@@ -68,7 +70,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDelegateAttributeValidation() throws Exception {
+    public void validateShouldDelegateAttributeValidation() {
         String requestId = UUID.randomUUID().toString();
         Assertion assertion = anAssertion()
                 .withSubject(aSubject().build())
@@ -80,7 +82,7 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
+    public void validateShouldThrowExceptionIfAnyAssertionDoesNotContainASignature() {
         String someID = UUID.randomUUID().toString();
         Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
 
@@ -88,7 +90,23 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
+    public void validateEidasShouldAllowAnEidasAssertionToNotContainASignature() {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
+
+        validator.validateEidas(assertion, "", assertion.getID());
+    }
+
+    @Test
+    public void validateEidasShouldValidateSignaturePresentIfSignatureExists() {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
+
+        assertThrows(SamlTransformationErrorException.class, () -> validator.validateEidas(assertion, "", assertion.getID()));
+    }
+
+    @Test
+    public void validateShouldThrowExceptionIfAnAssertionIsNotSigned() {
         String someID = UUID.randomUUID().toString();
 
         Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
@@ -97,35 +115,35 @@ public class AssertionValidatorTest {
     }
 
     @Test
-    public void validateShouldDoNothingIfAllAssertionsAreSigned() throws Exception {
+    public void validateShouldDoNothingIfAllAssertionsAreSigned() {
         Assertion assertion = anAssertion().buildUnencrypted();
 
         validator.validate(assertion, "", assertion.getID());
     }
 
     @Test
-    public void validateShouldThrowExceptionIfIdIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIdIsMissing() {
         Assertion assertion = anAssertion().withId(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
     }
 
     @Test
-    public void validateShouldThrowExceptionIfVersionIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsMissing() {
         Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
     }
 
     @Test
-    public void validateShouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
+    public void validateShouldThrowExceptionIfVersionIsNotSamlTwoPointZero() {
         Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
     }
 
     @Test
-    public void validateShouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+    public void validateShouldThrowExceptionIfIssueInstantIsMissing() {
         Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
 
         assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlAssertionsSignatureValidatorTest.java
@@ -52,6 +52,18 @@ public class SamlAssertionsSignatureValidatorTest {
         verify(samlMessageSignatureValidator).validate(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
+    @Test
+    public void shouldValidateEidasAssertionsWithAndWithoutSignature() {
+        final Assertion assertion1 = AssertionBuilder.anAssertion().withSignature(null).build();
+        final Assertion assertion2 = AssertionBuilder.anAssertion().build();
+        final List<Assertion> assertions = asList(assertion1, assertion2);
+
+        samlAssertionsSignatureValidator.validateEidas(assertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion1, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        verify(samlMessageSignatureValidator).validateEidasAssertion(assertion2, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldFailOnFirstBadlySignedAssertion() {
         final Assertion assertion1 = AssertionBuilder.anAssertion().withoutSigning().build();

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SamlMessageSignatureValidatorTest.java
@@ -32,7 +32,7 @@ public class SamlMessageSignatureValidatorTest {
     private final SamlMessageSignatureValidator samlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
 
     @Test
-    public void validateWithIssueShouldReturnBadResponseIfRequestSignatureIsMissing() {
+    public void validateShouldReturnBadResponseIfRequestSignatureIsMissing() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSignatureElement()
@@ -45,7 +45,21 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssueShouldReturnBadResponseIfRequestIsNotSigned() {
+    public void validateEidasAssertionShouldAcceptUnsignedAssertionsFromEidasCountries() {
+        final Assertion unsignedAssertion = anAssertion()
+            .withIssuer(anIssuer().withIssuerId(issuerId).build())
+            .withSignature(null)
+            .build();
+
+        SamlMessageSignatureValidator eidasSamlMessageSignatureValidator = new SamlMessageSignatureValidator(signatureValidator);
+
+        SamlValidationResponse signatureValidationResponse = eidasSamlMessageSignatureValidator.validateEidasAssertion(unsignedAssertion, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        assertThat(signatureValidationResponse.isOK()).isTrue();
+    }
+
+    @Test
+    public void validateShouldReturnBadResponseIfRequestIsNotSigned() {
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())
                 .withoutSigning()
@@ -58,7 +72,7 @@ public class SamlMessageSignatureValidatorTest {
     }
 
     @Test
-    public void validateWithIssueShouldReturnBadResponseIfRequestSignatureIsBad() {
+    public void validateShouldReturnBadResponseIfRequestSignatureIsBad() {
         Credential badCredential = new TestCredentialFactory(TestCertificateStrings.UNCHAINED_PUBLIC_CERT, TestCertificateStrings.UNCHAINED_PRIVATE_KEY).getSigningCredential();
         final AuthnRequest unsignedAuthnRequest = anAuthnRequest()
                 .withIssuer(anIssuer().withIssuerId(issuerId).build())


### PR DESCRIPTION
…ed""

We want eIDAS specific behaviour once again - when validating from an eIDAS flow we want to allow unsigned assertions so this reverts the revert that reverted the original work to provide a validateEidas method and corresponding tests.