### PR TITLE
EID-1603 Move EidasValidatorFactory to saml-lib

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/EidasValidatorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/EidasValidatorFactory.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.security;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.List;
+
+import static java.text.MessageFormat.format;
+
+public class EidasValidatorFactory {
+
+    private EidasMetadataResolverRepository eidasMetadataResolverRepository;
+
+    @Inject
+    public EidasValidatorFactory(EidasMetadataResolverRepository eidasMetadataResolverRepository) {
+        this.eidasMetadataResolverRepository = eidasMetadataResolverRepository;
+    }
+
+    public ValidatedResponse getValidatedResponse(Response response) {
+        SamlResponseSignatureValidator samlResponseSignatureValidator = new SamlResponseSignatureValidator(getSamlMessageSignatureValidator(response.getIssuer().getValue()));
+        return samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    public void getValidatedAssertion(ValidatedResponse validatedResponse, List<Assertion> decryptedAssertions) {
+        SamlAssertionsSignatureValidator samlAssertionsSignatureValidator = new SamlAssertionsSignatureValidator(getSamlMessageSignatureValidator(validatedResponse.getIssuer().getValue()));
+        samlAssertionsSignatureValidator.validateEidas(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    private SamlMessageSignatureValidator getSamlMessageSignatureValidator(String entityId) {
+        return eidasMetadataResolverRepository
+                .getSignatureTrustEngine(entityId)
+                .map(MetadataBackedSignatureValidator::withoutCertificateChainValidation)
+                .map(SamlMessageSignatureValidator::new)
+                .orElseThrow(() -> new SamlTransformationErrorException(format("Unable to find metadata resolver for entity Id {0}", entityId), Level.ERROR));
+    }
+
+}


### PR DESCRIPTION
There's a [PR here on the hub](https://github.com/alphagov/verify-hub/pull/367) to use this. That PR requires this to be merged.

The `EidasValidatorFactory` is used in the hub to validate the
signatures of SAML Responses and assertions from countries. We are going
to need to use this logic in the VSP and MSA as, due to countries not
signing assertions, the hub will be passing countries responses on to
the VSP/MSA without altering them.

The `EidasValidatorFactory` uses an `eidasMetadataResolverRepository`
which is responsible for fetching the countries trust anchors and
storing them in a trust store. The VSP and MSA will need to be
configured to do this.