### PR TITLE
EID-1609 Re-encrypt symmetric key for receiving RP

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/GenericHubProfileValidationSpecification.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/GenericHubProfileValidationSpecification.java
@@ -21,6 +21,8 @@ public class GenericHubProfileValidationSpecification extends SamlValidationSpec
     public static final String UNSUPPORTED_SIGNATURE_ENCRYPTION_ALGORITHM = "Signature algorithm {0} is not supported.";
     public static final String ENCRYPTION_ALGORITHM_SHOULD_BE_AES128 = "Assertion encrypted with unsupported encryption algorithm {0}, should be AES128.";
     public static final String UNABLE_TO_LOCATE_ENCRYPTED_KEY = "Unable to located encrypted key within assertion.";
+    public static final String UNABLE_TO_DECRYPT_ENCRYPTED_KEY = "Unable to decrypt XML encryption key with algorithm {0}.";
+    public static final String UNABLE_TO_ENCRYPT_SYMMETRIC_KEY = "Unable to encrypt XML encryption key.";
     public static final String KEY_ENCRYPTION_ALGORITHM_SHOULD_BE_RSAOAEP = "Key encrypted with unsupported encryption algorithm {0}, should be RSAOAEP.";
 
 

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/AssertionDecrypter.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/AssertionDecrypter.java
@@ -4,14 +4,23 @@ import com.google.common.collect.ImmutableList;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.xmlsec.encryption.EncryptedKey;
 import org.opensaml.xmlsec.encryption.support.DecryptionException;
 import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
 import uk.gov.ida.saml.security.validators.ValidatedEncryptedAssertionContainer;
 import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
 
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.unableToDecrypt;
+import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.unableToDecryptXMLEncryptionKey;
 
 public class AssertionDecrypter {
 
@@ -42,5 +51,31 @@ public class AssertionDecrypter {
         }
 
         return assertions.build();
+    }
+
+    public List<String> getReEncryptedKeys(ValidatedEncryptedAssertionContainer container,
+                                           SecretKeyEncrypter secretKeyEncrypter,
+                                           String entityId) {
+
+        final List<String> base64String = new ArrayList<>();
+        String algorithm = "";
+
+        for (EncryptedAssertion encryptedAssertion : container.getEncryptedAssertions()) {
+            Iterator<EncryptedKey> encryptedKeyIterator = encryptedAssertion.getEncryptedKeys().iterator();
+            while (encryptedKeyIterator.hasNext()) {
+                try {
+                    EncryptedKey encryptedKey = encryptedKeyIterator.next();
+                    algorithm = encryptedKey.getEncryptionMethod().getAlgorithm();
+                    Key decryptedKey = decrypter.decryptKey(encryptedKey, algorithm);
+
+                    base64String.add(secretKeyEncrypter.encryptKeyForEntity(decryptedKey, entityId));
+                } catch (DecryptionException e) {
+                    if (!encryptedKeyIterator.hasNext()) {
+                        throw new SamlFailedToDecryptException(unableToDecryptXMLEncryptionKey(algorithm), e);
+                    }
+                }
+            }
+        }
+        return base64String;
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
@@ -18,11 +18,10 @@ public class SecretKeyEncrypter {
     private KeyStoreBackedEncryptionCredentialResolver credentialFactory;
 
     public SecretKeyEncrypter(KeyStoreBackedEncryptionCredentialResolver credentialFactory) {
-            this.credentialFactory = credentialFactory;
+        this.credentialFactory = credentialFactory;
     }
 
-    public String encryptKeyForEntity(Key secretKey, String entityId)
-             {
+    public String encryptKeyForEntity(Key secretKey, String entityId) {
         PublicKey publicKey = credentialFactory.getEncryptingCredential(entityId).getPublicKey();
         try {
             Cipher cipher = Cipher.getInstance(publicKey.getAlgorithm());

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.saml.security;
+
+import org.bouncycastle.util.encoders.Base64;
+import uk.gov.ida.saml.security.exception.SamlFailedToEncryptException;
+
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+
+import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.unableToEncryptXMLEncryptionKey;
+
+public class SecretKeyEncrypter {
+
+    private KeyStoreBackedEncryptionCredentialResolver credentialFactory;
+
+    public SecretKeyEncrypter(KeyStoreBackedEncryptionCredentialResolver credentialFactory) {
+            this.credentialFactory = credentialFactory;
+    }
+
+    public String encryptKeyForEntity(Key secretKey, String entityId)
+             {
+        PublicKey publicKey = credentialFactory.getEncryptingCredential(entityId).getPublicKey();
+        try {
+            Cipher cipher = Cipher.getInstance(publicKey.getAlgorithm());
+            cipher.init(Cipher.WRAP_MODE, publicKey);
+            return Base64.toBase64String(cipher.wrap(secretKey));
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException e) {
+            throw new SamlFailedToEncryptException(unableToEncryptXMLEncryptionKey(), e);
+        }
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/errors/SamlTransformationErrorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/errors/SamlTransformationErrorFactory.java
@@ -26,6 +26,14 @@ public final class SamlTransformationErrorFactory {
         return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNABLE_TO_DECRYPT, message);
     }
 
+    public static SamlValidationSpecificationFailure unableToDecryptXMLEncryptionKey(final String algorithm) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNABLE_TO_DECRYPT_ENCRYPTED_KEY, algorithm);
+    }
+
+    public static SamlValidationSpecificationFailure unableToEncryptXMLEncryptionKey() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNABLE_TO_ENCRYPT_SYMMETRIC_KEY);
+    }
+
     public static SamlValidationSpecificationFailure unsupportedSignatureEncryptionAlgortithm(final String algorithm) {
         return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNSUPPORTED_SIGNATURE_ENCRYPTION_ALGORITHM, algorithm);
     }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/exception/SamlFailedToEncryptException.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/exception/SamlFailedToEncryptException.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.security.exception;
+
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+public class SamlFailedToEncryptException extends SamlTransformationErrorException {
+
+    public SamlFailedToEncryptException(String errorMessage, Exception cause, Level logLevel) {
+        super(errorMessage, cause, logLevel);
+    }
+
+    public SamlFailedToEncryptException(String errorMessage, Level logLevel) {
+        super(errorMessage, logLevel);
+    }
+
+    public SamlFailedToEncryptException(SamlValidationSpecificationFailure failure, Exception cause) {
+        super(failure.getErrorMessage(), cause, failure.getLogLevel());
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/AssertionDecrypterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/AssertionDecrypterTest.java
@@ -1,16 +1,30 @@
 package uk.gov.ida.saml.security;
 
+import net.shibboleth.utilities.java.support.collection.LockableClassToInstanceMultiMap;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opensaml.core.xml.Namespace;
+import org.opensaml.core.xml.NamespaceManager;
+import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.core.xml.schema.XSBooleanValue;
+import org.opensaml.core.xml.util.IDIndex;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.CarriedKeyName;
+import org.opensaml.xmlsec.encryption.CipherData;
+import org.opensaml.xmlsec.encryption.EncryptedKey;
+import org.opensaml.xmlsec.encryption.EncryptionMethod;
+import org.opensaml.xmlsec.encryption.EncryptionProperties;
+import org.opensaml.xmlsec.encryption.ReferenceList;
+import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.w3c.dom.Element;
 import uk.gov.ida.common.shared.security.PrivateKeyFactory;
 import uk.gov.ida.common.shared.security.PublicKeyFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
@@ -20,14 +34,19 @@ import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
 import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.security.saml.TestCredentialFactory;
 import uk.gov.ida.saml.security.saml.builders.EncryptedAssertionBuilder;
+import uk.gov.ida.saml.security.saml.builders.ResponseBuilder;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +55,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.security.saml.builders.EncryptedAssertionBuilder.anEncryptedAssertionBuilder;
 import static uk.gov.ida.saml.security.saml.builders.IssuerBuilder.anIssuer;
 import static uk.gov.ida.saml.security.saml.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.security.saml.builders.ResponseBuilder.aResponseWithNoEncryptedAssertions;
 
 @RunWith(OpenSAMLMockitoRunner.class)
 public class AssertionDecrypterTest {
@@ -73,7 +93,7 @@ public class AssertionDecrypterTest {
     }
 
     @Test
-    public void shouldProvideReEncryptedSymmetricKeys() throws Exception {
+    public void shouldProvideOneReEncryptedSymmetricKey() throws Exception {
         String AN_ENTITY_ID = "ministry-of-pies";
         KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
         Credential credential = new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT, null).getEncryptingCredential();
@@ -81,7 +101,66 @@ public class AssertionDecrypterTest {
         SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
         final Response response = responseForAssertion(EncryptedAssertionBuilder.anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId(assertionId).build());
         final List<String> base64EncryptedSymmetricKeys = assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(response), secretKeyEncrypter, AN_ENTITY_ID);
-        assertThat(base64EncryptedSymmetricKeys.size()).isGreaterThan(0);
+        assertThat(base64EncryptedSymmetricKeys.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldProvideThreeReEncryptedSymmetricKeys() throws Exception {
+        String AN_ENTITY_ID = "ministry-of-pies";
+        KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
+        Credential credential = new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT, null).getEncryptingCredential();
+        when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(credential);
+        SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
+        final Response response = responseForMultipleAssertions(
+                anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId(assertionId).build(),
+                anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId(assertionId).build(),
+                anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId(assertionId).build());
+        final List<String> base64EncryptedSymmetricKeys = assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(response), secretKeyEncrypter, AN_ENTITY_ID);
+        assertThat(base64EncryptedSymmetricKeys.size()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldProvideZeroReEncryptedSymmetricKeys() throws Exception {
+        String AN_ENTITY_ID = "ministry-of-pies";
+        KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
+
+        SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
+        final Response response = responseWithZeroEncryptedAssertions();
+        final List<String> base64EncryptedSymmetricKeys = assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(response), secretKeyEncrypter, AN_ENTITY_ID);
+        assertThat(base64EncryptedSymmetricKeys.size()).isEqualTo(0);
+    }
+
+    @Test(expected = SamlFailedToDecryptException.class)
+    public void shouldThrowExceptionIfNoKeyCanBeDecrypted() throws MarshallingException, SignatureException {
+        String AN_ENTITY_ID = "ministry-of-pies";
+        KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
+
+        final EncryptedAssertion badlyEncryptedAssertion = anEncryptedAssertionBuilder().withId(assertionId).withEncrypterCredential(
+                new TestCredentialFactory(TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT, null).getEncryptingCredential()).build();
+
+        final Response response = responseForAssertion(badlyEncryptedAssertion);
+        SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
+        assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(response), secretKeyEncrypter, AN_ENTITY_ID);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfSomeKeyCanBeDecrypted() throws MarshallingException, SignatureException {
+        String AN_ENTITY_ID = "ministry-of-pies";
+        KeyStoreBackedEncryptionCredentialResolver credentialResolver = mock(KeyStoreBackedEncryptionCredentialResolver.class);
+        Credential credential = new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT, null).getEncryptingCredential();
+        when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(credential);
+
+        EncryptedAssertion encryptedAssertion = anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId(assertionId).build();
+        EncryptedKey validEncryptedKey = encryptedAssertion.getEncryptedKeys().get(0);
+        BadEncryptedKey badEncryptedKey = new BadEncryptedKey(validEncryptedKey);
+
+        encryptedAssertion.getEncryptedKeys().add(0, badEncryptedKey);
+
+        final Response response = responseForMultipleAssertions(
+                encryptedAssertion);
+        SecretKeyEncrypter secretKeyEncrypter = new SecretKeyEncrypter(credentialResolver);
+        final List<String> base64EncryptedSymmetricKeys = assertionDecrypter.getReEncryptedKeys(new ValidatedResponse(response), secretKeyEncrypter, AN_ENTITY_ID);
+        assertThat(base64EncryptedSymmetricKeys.size()).isEqualTo(1);
     }
 
     @Test (expected = SamlFailedToDecryptException.class)
@@ -101,4 +180,306 @@ public class AssertionDecrypterTest {
                 .addEncryptedAssertion(encryptedAssertion)
                 .build();
     }
+
+    private Response responseForMultipleAssertions(EncryptedAssertion ... encryptedAssertions) throws MarshallingException, SignatureException {
+        ResponseBuilder aResponseBuilder = aResponse()
+                .withSigningCredential(keyStoreCredentialRetriever.getSigningCredential())
+                .withIssuer(anIssuer().withIssuerId(TestEntityIds.STUB_IDP_ONE).build());
+                Arrays.stream(encryptedAssertions).forEach(aResponseBuilder::addEncryptedAssertion);
+                return aResponseBuilder.build();
+    }
+
+    private Response responseWithZeroEncryptedAssertions() throws Exception {
+        return aResponseWithNoEncryptedAssertions()
+                .withSigningCredential(keyStoreCredentialRetriever.getSigningCredential())
+                .withIssuer(anIssuer().withIssuerId(TestEntityIds.STUB_IDP_ONE).build())
+                .build();
+    }
+
+    private class BadEncryptedKey implements EncryptedKey {
+        /*
+        * As convoluted as this seems, I think it's the most straightforward way to get a key that can't be decrypted
+        * into an encrypted assertion.  I'd be delighted if there was a better way to do it.
+         */
+        private EncryptedKey validEncryptedKey;
+
+
+        public BadEncryptedKey(EncryptedKey validEncryptedKey) {
+            this.validEncryptedKey = validEncryptedKey;
+        }
+
+        @Override
+        @Nullable
+        public String getRecipient() {
+            return validEncryptedKey.getRecipient();
+        }
+
+        @Override
+        public void setRecipient(@Nullable String newRecipient) {
+            validEncryptedKey.setRecipient(newRecipient);
+        }
+
+        @Override
+        @Nullable
+        public ReferenceList getReferenceList() {
+            return validEncryptedKey.getReferenceList();
+        }
+
+        @Override
+        public void setReferenceList(@Nullable ReferenceList newReferenceList) {
+            validEncryptedKey.setReferenceList(newReferenceList);
+        }
+
+        @Override
+        @Nullable
+        public CarriedKeyName getCarriedKeyName() {
+            return validEncryptedKey.getCarriedKeyName();
+        }
+
+        @Override
+        public void setCarriedKeyName(@Nullable CarriedKeyName newCarriedKeyName) {
+            validEncryptedKey.setCarriedKeyName(newCarriedKeyName);
+        }
+
+        @Override
+        @Nullable
+        public String getID() {
+            return validEncryptedKey.getID();
+        }
+
+        @Override
+        public void setID(@Nullable String newID) {
+            validEncryptedKey.setID(newID);
+        }
+
+        @Override
+        @Nullable
+        public String getType() {
+            return validEncryptedKey.getType();
+        }
+
+        @Override
+        public void setType(@Nullable String newType) {
+            validEncryptedKey.setType(newType);
+        }
+
+        @Override
+        @Nullable
+        public String getMimeType() {
+            return validEncryptedKey.getMimeType();
+        }
+
+        @Override
+        public void setMimeType(@Nullable String newMimeType) {
+            validEncryptedKey.setMimeType(newMimeType);
+        }
+
+        @Override
+        @Nullable
+        public String getEncoding() {
+            return validEncryptedKey.getEncoding();
+        }
+
+        @Override
+        public void setEncoding(@Nullable String newEncoding) {
+            validEncryptedKey.setEncoding(newEncoding);
+        }
+
+        @Override
+        @Nullable
+        public EncryptionMethod getEncryptionMethod() {
+            EncryptionMethod mockEncryptionMethod = mock(EncryptionMethod.class);
+            when(mockEncryptionMethod.getAlgorithm()).thenReturn("I'll eat my hat if this is a valid algorithm");
+            return mockEncryptionMethod;
+        }
+
+        @Override
+        public void setEncryptionMethod(@Nullable EncryptionMethod newEncryptionMethod) {
+            validEncryptedKey.setEncryptionMethod(newEncryptionMethod);
+        }
+
+        @Override
+        @Nullable
+        public KeyInfo getKeyInfo() {
+            return validEncryptedKey.getKeyInfo();
+        }
+
+        @Override
+        public void setKeyInfo(@Nullable KeyInfo newKeyInfo) {
+            validEncryptedKey.setKeyInfo(newKeyInfo);
+        }
+
+        @Override
+        @Nullable
+        public CipherData getCipherData() {
+            return validEncryptedKey.getCipherData();
+        }
+
+        @Override
+        public void setCipherData(@Nullable CipherData newCipherData) {
+            validEncryptedKey.setCipherData(newCipherData);
+        }
+
+        @Override
+        @Nullable
+        public EncryptionProperties getEncryptionProperties() {
+            return validEncryptedKey.getEncryptionProperties();
+        }
+
+        @Override
+        public void setEncryptionProperties(@Nullable EncryptionProperties newEncryptionProperties) {
+            validEncryptedKey.setEncryptionProperties(newEncryptionProperties);
+        }
+
+        @Override
+        public void detach() {
+            validEncryptedKey.detach();
+        }
+
+        @Override
+        @Nullable
+        public Element getDOM() {
+            return validEncryptedKey.getDOM();
+        }
+
+        @Override
+        @Nonnull
+        public QName getElementQName() {
+            return validEncryptedKey.getElementQName();
+        }
+
+        @Override
+        @Nonnull
+        public IDIndex getIDIndex() {
+            return validEncryptedKey.getIDIndex();
+        }
+
+        @Override
+        @Nonnull
+        public NamespaceManager getNamespaceManager() {
+            return validEncryptedKey.getNamespaceManager();
+        }
+
+        @Override
+        @Nonnull
+        public Set<Namespace> getNamespaces() {
+            return validEncryptedKey.getNamespaces();
+        }
+
+        @Override
+        @Nullable
+        public String getNoNamespaceSchemaLocation() {
+            return validEncryptedKey.getNoNamespaceSchemaLocation();
+        }
+
+        @Override
+        @Nullable
+        public List<XMLObject> getOrderedChildren() {
+            return validEncryptedKey.getOrderedChildren();
+        }
+
+        @Override
+        @Nullable
+        public XMLObject getParent() {
+            return validEncryptedKey.getParent();
+        }
+
+        @Override
+        @Nullable
+        public String getSchemaLocation() {
+            return validEncryptedKey.getSchemaLocation();
+        }
+
+        @Override
+        @Nullable
+        public QName getSchemaType() {
+            return validEncryptedKey.getSchemaType();
+        }
+
+        @Override
+        public boolean hasChildren() {
+            return validEncryptedKey.hasChildren();
+        }
+
+        @Override
+        public boolean hasParent() {
+            return validEncryptedKey.hasParent();
+        }
+
+        @Override
+        public void releaseChildrenDOM(boolean propagateRelease) {
+            validEncryptedKey.releaseChildrenDOM(propagateRelease);
+        }
+
+        @Override
+        public void releaseDOM() {
+            validEncryptedKey.releaseDOM();
+        }
+
+        @Override
+        public void releaseParentDOM(boolean propagateRelease) {
+            validEncryptedKey.releaseParentDOM(propagateRelease);
+        }
+
+        @Override
+        @Nullable
+        public XMLObject resolveID(@Nonnull String id) {
+            return validEncryptedKey.resolveID(id);
+        }
+
+        @Override
+        @Nullable
+        public XMLObject resolveIDFromRoot(@Nonnull String id) {
+            return validEncryptedKey.resolveIDFromRoot(id);
+        }
+
+        @Override
+        public void setDOM(@Nullable Element dom) {
+            validEncryptedKey.setDOM(dom);
+        }
+
+        @Override
+        public void setNoNamespaceSchemaLocation(@Nullable String location) {
+            validEncryptedKey.setNoNamespaceSchemaLocation(location);
+        }
+
+        @Override
+        public void setParent(@Nullable XMLObject parent) {
+            validEncryptedKey.setParent(parent);
+        }
+
+        @Override
+        public void setSchemaLocation(@Nullable String location) {
+            validEncryptedKey.setSchemaLocation(location);
+        }
+
+        @Override
+        @Nullable
+        public Boolean isNil() {
+            return validEncryptedKey.isNil();
+        }
+
+        @Override
+        @Nullable
+        public XSBooleanValue isNilXSBoolean() {
+            return validEncryptedKey.isNilXSBoolean();
+        }
+
+        @Override
+        public void setNil(@Nullable Boolean newNil) {
+            validEncryptedKey.setNil(newNil);
+        }
+
+        @Override
+        public void setNil(@Nullable XSBooleanValue newNil) {
+            validEncryptedKey.setNil(newNil);
+        }
+
+        @Override
+        @Nonnull
+        public LockableClassToInstanceMultiMap<Object> getObjectMetadata() {
+            return validEncryptedKey.getObjectMetadata();
+        }
+    }
 }
+

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
@@ -1,0 +1,104 @@
+package uk.gov.ida.saml.security;
+
+import org.apache.commons.ssl.util.PublicKeyDeriver;
+import org.apache.xml.security.exceptions.Base64DecodingException;
+import org.apache.xml.security.utils.Base64;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.security.credential.Credential;
+import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SecretKeyEncrypterTest {
+    @Mock
+    KeyStoreBackedEncryptionCredentialResolver credentialResolver;
+    @Mock
+    Credential mockCredential;
+
+    private SecretKeyEncrypter testSubject;
+    private static final String AN_ENTITY_ID = "ministry-of-pies";
+
+    private static String base64RsaPrivateKey =
+            "MIIEowIBAAKCAQEAzAmUBx0uNqYwzqH/56qh2VOPxC3Ip+As93MpTfbYi6voZGA0\n" +
+            "DAHxhFIDoiVDvmyVM+WEARuUB4EF8FIPv8vcx63s192UBKv2PuIc0dikOObTMdjR\n" +
+            "/7fnL++HHPc45tlThaVyT4PLUAw8ML9yaomHFb53wr/DXVi/DBTE3uCT+Uf1UJCX\n" +
+            "DMZDS/kbMH4t90hmAigRobgnKDp5unuB5n5zh+VL6yk7sNRhHY8Xr3R5hYb/87Sy\n" +
+            "t3P9z84+6JhacbZUR28eRl+zMauheiLtUmyo3VPfoGrCsS7mpWy4OzvfD7UeAv52\n" +
+            "EuQJ+wINf94+BB7EKXiM939GSLb6Kw4TOc6m3wIDAQABAoIBAGjv/Cv0fBIrQyri\n" +
+            "8qSJg5gse+Jf0bVVfIr/tZydeh3LmkgVmm8aiMaPD8NS+xZy7gG050FSl72MRCun\n" +
+            "aOYxySkBcLBNC5Wjg5Av5raef0esn64hX0/vm31x6cGh/Kft2iEASFxQ4j4XLNW9\n" +
+            "gPD+LnWmch29VpMp04g5Hk+qnTA1QI24CpMK1Dystz3b1mcfmnxfnQlFhEGB1atQ\n" +
+            "hRqlTaiswZY9Eq45KLw03V21gh9Wxsze1xkuWW35yMIUv4sc9k4ZBQPvAHvaIdlW\n" +
+            "otRgLyHQOixfiCYgGXFjLoA0dkbv5mjNpLyGLUL9XeuMgrIwUKNyVIFpEq9kvKTz\n" +
+            "SmlibkECgYEA82dDW7idbm411iYT4G8SRSxXBdiDfETAG7gFLuty+vRCVVVJGjWO\n" +
+            "u3qnoPCMhrjmiXtTyqHDGjTAtn6glUckHTayTkq6CLQa1aOjJbubUF4p/m7gMdTZ\n" +
+            "wVorHEhE8DlHNyGki9JY0kMq8CLFwrtE0mMA3LaRnoMQ7tNsVpeDIA8CgYEA1pjG\n" +
+            "KJNqeUX1yvfUV+4XheVHiKw/wowOz9YHjeEYzj/cD6RFUhxRyrhqnnqW1Y1DAwMs\n" +
+            "hBKNAVh3EZEpiToXd7yyCL3OzDyP6uAcX7YGnxH/JlmN7yIs1ZCMktMO0s0WBDjs\n" +
+            "FBHELrOVD5gqvQHUYOiMA2gXgOl8kyj30wyuPDECgYAjv0G0QcvVQRhlCBiZOJbN\n" +
+            "U/K/6Al/gbVZHNCeEHRFiQQI9kqTL9RzklL2Hv30d0lcXaFzvAgkXCUFaFl7MwSJ\n" +
+            "ydOsDet+hbz/LVYzn3by+bFfLbd9eg41CGIWeEKvqSndXfKFmnHzB2xR8jlrHQfB\n" +
+            "gkrJH4MJbaRZ/vEFUqEuXwKBgQCjCZjrdOxczNEr7lPuph5LBOHvLWaXqQ8LykEd\n" +
+            "Atp0wEGxxI1CD+/4Q1oFo397KYKzBDNK+EkWr55uw0m6T19LAhqE16gItS5mNPR5\n" +
+            "pvKq4eJmwX07JEzJyLN0TVOixlumw5Rgvwq8rIVgPqyhwoUXRzYw1GGe+EVEDMkU\n" +
+            "GDs70QKBgC65ybyZq6TIiS3t6FNpHOcItEDHOxn0sds0hIMbSOxN0fal/oPENTwF\n" +
+            "DZcF7BqDilVuaFbkkHX0agKG6w+LuX8U/HfqLax6jxjwsNR34akknFvpDiIASpll\n" +
+            "DjzEEarH/ZICQIGxynujKL7H/SCSFFFzPz+T91V/5aNPiI7VDwlc";
+
+    private static PrivateKey privateKey;
+
+    @Test
+    public void shouldSuccessfullyEncryptASecretKey() throws Exception {
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.decode(base64RsaPrivateKey));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        privateKey = keyFactory.generatePrivate(keySpec);
+
+        PublicKey publicKey = PublicKeyDeriver.derivePublicKey(privateKey);
+
+        when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(mockCredential);
+        when(mockCredential.getPublicKey()).thenReturn(publicKey);
+
+        testSubject = new SecretKeyEncrypter(credentialResolver);
+
+        SecretKey unEncryptedSecretKey = getSecretKey();
+
+        String encryptedSecretKey = testSubject.encryptKeyForEntity(unEncryptedSecretKey, AN_ENTITY_ID);
+
+        Key decryptedSecretKey = decryptSecretKey(encryptedSecretKey);
+        assertThat(decryptedSecretKey.getEncoded()).isEqualTo(unEncryptedSecretKey.getEncoded());
+    }
+
+    private SecretKey getSecretKey() throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("DES");
+        keyGenerator.init(56);
+        return keyGenerator.generateKey();
+    }
+
+    private Key decryptSecretKey(String base64EncryptedSecretKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, Base64DecodingException {
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.UNWRAP_MODE, privateKey);
+        return cipher.unwrap(Base64.decode(base64EncryptedSecretKey), "RSA", Cipher.SECRET_KEY);
+    }
+
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
@@ -21,9 +21,8 @@ import static org.mockito.Mockito.when;
 @RunWith(OpenSAMLMockitoRunner.class)
 public class SecretKeyEncrypterTest {
     @Mock
-    KeyStoreBackedEncryptionCredentialResolver credentialResolver;
+    private KeyStoreBackedEncryptionCredentialResolver credentialResolver;
 
-    private SecretKeyEncrypter testSubject;
     private static final String AN_ENTITY_ID = "ministry-of-pies";
 
     private Credential credential = new TestCredentialFactory(
@@ -33,6 +32,8 @@ public class SecretKeyEncrypterTest {
 
     @Test
     public void shouldSuccessfullyEncryptASecretKey() throws Exception {
+
+        SecretKeyEncrypter testSubject;
 
         when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(credential);
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyEncrypterTest.java
@@ -1,27 +1,19 @@
 package uk.gov.ida.saml.security;
 
-import org.apache.commons.ssl.util.PublicKeyDeriver;
-import org.apache.xml.security.exceptions.Base64DecodingException;
 import org.apache.xml.security.utils.Base64;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.opensaml.security.credential.Credential;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.security.saml.TestCredentialFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
-import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Security;
-import java.security.spec.PKCS8EncodedKeySpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -30,54 +22,19 @@ import static org.mockito.Mockito.when;
 public class SecretKeyEncrypterTest {
     @Mock
     KeyStoreBackedEncryptionCredentialResolver credentialResolver;
-    @Mock
-    Credential mockCredential;
 
     private SecretKeyEncrypter testSubject;
     private static final String AN_ENTITY_ID = "ministry-of-pies";
 
-    private static String base64RsaPrivateKey =
-            "MIIEowIBAAKCAQEAzAmUBx0uNqYwzqH/56qh2VOPxC3Ip+As93MpTfbYi6voZGA0\n" +
-            "DAHxhFIDoiVDvmyVM+WEARuUB4EF8FIPv8vcx63s192UBKv2PuIc0dikOObTMdjR\n" +
-            "/7fnL++HHPc45tlThaVyT4PLUAw8ML9yaomHFb53wr/DXVi/DBTE3uCT+Uf1UJCX\n" +
-            "DMZDS/kbMH4t90hmAigRobgnKDp5unuB5n5zh+VL6yk7sNRhHY8Xr3R5hYb/87Sy\n" +
-            "t3P9z84+6JhacbZUR28eRl+zMauheiLtUmyo3VPfoGrCsS7mpWy4OzvfD7UeAv52\n" +
-            "EuQJ+wINf94+BB7EKXiM939GSLb6Kw4TOc6m3wIDAQABAoIBAGjv/Cv0fBIrQyri\n" +
-            "8qSJg5gse+Jf0bVVfIr/tZydeh3LmkgVmm8aiMaPD8NS+xZy7gG050FSl72MRCun\n" +
-            "aOYxySkBcLBNC5Wjg5Av5raef0esn64hX0/vm31x6cGh/Kft2iEASFxQ4j4XLNW9\n" +
-            "gPD+LnWmch29VpMp04g5Hk+qnTA1QI24CpMK1Dystz3b1mcfmnxfnQlFhEGB1atQ\n" +
-            "hRqlTaiswZY9Eq45KLw03V21gh9Wxsze1xkuWW35yMIUv4sc9k4ZBQPvAHvaIdlW\n" +
-            "otRgLyHQOixfiCYgGXFjLoA0dkbv5mjNpLyGLUL9XeuMgrIwUKNyVIFpEq9kvKTz\n" +
-            "SmlibkECgYEA82dDW7idbm411iYT4G8SRSxXBdiDfETAG7gFLuty+vRCVVVJGjWO\n" +
-            "u3qnoPCMhrjmiXtTyqHDGjTAtn6glUckHTayTkq6CLQa1aOjJbubUF4p/m7gMdTZ\n" +
-            "wVorHEhE8DlHNyGki9JY0kMq8CLFwrtE0mMA3LaRnoMQ7tNsVpeDIA8CgYEA1pjG\n" +
-            "KJNqeUX1yvfUV+4XheVHiKw/wowOz9YHjeEYzj/cD6RFUhxRyrhqnnqW1Y1DAwMs\n" +
-            "hBKNAVh3EZEpiToXd7yyCL3OzDyP6uAcX7YGnxH/JlmN7yIs1ZCMktMO0s0WBDjs\n" +
-            "FBHELrOVD5gqvQHUYOiMA2gXgOl8kyj30wyuPDECgYAjv0G0QcvVQRhlCBiZOJbN\n" +
-            "U/K/6Al/gbVZHNCeEHRFiQQI9kqTL9RzklL2Hv30d0lcXaFzvAgkXCUFaFl7MwSJ\n" +
-            "ydOsDet+hbz/LVYzn3by+bFfLbd9eg41CGIWeEKvqSndXfKFmnHzB2xR8jlrHQfB\n" +
-            "gkrJH4MJbaRZ/vEFUqEuXwKBgQCjCZjrdOxczNEr7lPuph5LBOHvLWaXqQ8LykEd\n" +
-            "Atp0wEGxxI1CD+/4Q1oFo397KYKzBDNK+EkWr55uw0m6T19LAhqE16gItS5mNPR5\n" +
-            "pvKq4eJmwX07JEzJyLN0TVOixlumw5Rgvwq8rIVgPqyhwoUXRzYw1GGe+EVEDMkU\n" +
-            "GDs70QKBgC65ybyZq6TIiS3t6FNpHOcItEDHOxn0sds0hIMbSOxN0fal/oPENTwF\n" +
-            "DZcF7BqDilVuaFbkkHX0agKG6w+LuX8U/HfqLax6jxjwsNR34akknFvpDiIASpll\n" +
-            "DjzEEarH/ZICQIGxynujKL7H/SCSFFFzPz+T91V/5aNPiI7VDwlc";
-
-    private static PrivateKey privateKey;
+    private Credential credential = new TestCredentialFactory(
+            TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT,
+            TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY)
+            .getEncryptionKeyPair();
 
     @Test
     public void shouldSuccessfullyEncryptASecretKey() throws Exception {
 
-        Security.addProvider(new BouncyCastleProvider());
-
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.decode(base64RsaPrivateKey));
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        privateKey = keyFactory.generatePrivate(keySpec);
-
-        PublicKey publicKey = PublicKeyDeriver.derivePublicKey(privateKey);
-
-        when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(mockCredential);
-        when(mockCredential.getPublicKey()).thenReturn(publicKey);
+        when(credentialResolver.getEncryptingCredential(AN_ENTITY_ID)).thenReturn(credential);
 
         testSubject = new SecretKeyEncrypter(credentialResolver);
 
@@ -95,9 +52,9 @@ public class SecretKeyEncrypterTest {
         return keyGenerator.generateKey();
     }
 
-    private Key decryptSecretKey(String base64EncryptedSecretKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, Base64DecodingException {
+    private Key decryptSecretKey(String base64EncryptedSecretKey) throws Exception {
         Cipher cipher = Cipher.getInstance("RSA");
-        cipher.init(Cipher.UNWRAP_MODE, privateKey);
+        cipher.init(Cipher.UNWRAP_MODE, credential.getPrivateKey());
         return cipher.unwrap(Base64.decode(base64EncryptedSecretKey), "RSA", Cipher.SECRET_KEY);
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/TestCredentialFactory.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/TestCredentialFactory.java
@@ -32,16 +32,7 @@ public class TestCredentialFactory {
 
     public Credential getSigningCredential() {
 
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.decodeBase64(privateCert));
-
-        PrivateKey privateKey;
-        try {
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            privateKey = keyFactory.generatePrivate(keySpec);
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw propagate(e);
-        }
-        BasicCredential credential = new BasicCredential(getPublicKey(), privateKey);
+        BasicCredential credential = new BasicCredential(getPublicKey(), getPrivateKey());
 
         credential.setUsageType(UsageType.SIGNING);
         return credential;
@@ -54,6 +45,12 @@ public class TestCredentialFactory {
         return credential;
     }
 
+    public Credential getEncryptionKeyPair() {
+        BasicCredential credential = new BasicCredential(getPublicKey(), getPrivateKey());
+        credential.setUsageType(UsageType.ENCRYPTION);
+        return credential;
+    }
+
     private PublicKey getPublicKey() {
         PublicKey publicKey;
         try {
@@ -62,6 +59,16 @@ public class TestCredentialFactory {
             throw propagate(e);
         }
         return publicKey;
+    }
+
+    private PrivateKey getPrivateKey() {
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.decodeBase64(privateCert));
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePrivate(keySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw propagate(e);
+        }
     }
 
     public static PublicKey createPublicKey(String partialCert) throws CertificateException, UnsupportedEncodingException {

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
@@ -17,6 +17,7 @@ import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.security.saml.TestSamlObjectFactory;
 
 import java.util.ArrayList;
@@ -52,8 +53,12 @@ public class ResponseBuilder {
 
     public static ResponseBuilder aResponse() {
         ResponseBuilder responseBuilder = new ResponseBuilder();
-        responseBuilder.defaultEncryptedAssertion = EncryptedAssertionBuilder.anEncryptedAssertionBuilder().build();
+        responseBuilder.defaultEncryptedAssertion = EncryptedAssertionBuilder.anEncryptedAssertionBuilder().withPublicEncryptionCert(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT).withId("foo").build();
         return responseBuilder;
+    }
+
+    public static ResponseBuilder aResponseWithNoEncryptedAssertions() {
+        return new ResponseBuilder();
     }
 
     public Response build() throws MarshallingException, SignatureException {


### PR DESCRIPTION
In order to maintain trust when receiving unsigned assertions we need to provide the original signed SAML message to the RP. The RP can only decrypt encrypted assertions if it has the symmetric key to do so but in the original SAML, it's encrypted for the hub so we need to decrypt the symmetric key(s) and re-encrypt it for the receiving RP and send it in a SAML form.  This PR takes care of the decryption / re-encryption of the symmetric key(s).

Add method to assertion decrypter to enable retrieval of encrypted symmetric keys.

Add class to encrypt the symmetric keys (known as secret keys) so the RP can un-encrypt them.

Add some exception handling so that the methods are consistent with the the rest of the library.  How that can be improved or altered is open to suggestions.

Follow the none, one and many approach to testing - with those numbers of encrypted assertions being tested. Also test Exceptions being thrown and not being thrown.

Create a few extra methods in the test framework to support the extra tests.

Add a private class that enables us to test the multiple keys, one of which can't be decrypted case - the class implements the EncryptedKey interface and forwards messages to an instance of a valid key for all methods except one that returns the EncryptionMethod method - that method returns a cunningly crafted mock that will cause a DecryptionException to be thrown.

I'm pretty confident that it's a better approach than a mock because there are lots and lots of things that would need to be When-Then-ed.