### PR TITLE
Decrypt eIDAS unsigned assertions before creating a MatchingDataSet for the MSA

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/IdaConstants.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/IdaConstants.java
@@ -55,6 +55,18 @@ public interface IdaConstants {
             String FRIENDLY_NAME = "PlaceOfBirth";
             String NAME = "http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth";
         }
+
+        interface UnsignedAssertions {
+            interface EidasSamlResponse {
+                String FRIENDLY_NAME = "Base64 encoded eIDAS SAML response";
+                String NAME = "EIDAS_Unsigned_Assertion_SAML_Response";
+            }
+
+            interface EncryptedSecretKeys {
+                String FRIENDLY_NAME = "Set of ephemeral secret keys encryped for a Government Service";
+                String NAME = "EIDAS_Unsigned_Assertion_encrypted_secret_keys";
+            }
+        }
     }
 
     interface Attributes_1_1 {

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/IdaConstants.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/IdaConstants.java
@@ -63,7 +63,7 @@ public interface IdaConstants {
             }
 
             interface EncryptedSecretKeys {
-                String FRIENDLY_NAME = "Set of ephemeral secret keys encryped for a Government Service";
+                String FRIENDLY_NAME = "Set of ephemeral secret keys encrypted for a Government Service";
                 String NAME = "EIDAS_Unsigned_Assertion_encrypted_secret_keys";
             }
         }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -33,7 +33,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
 
     public EidasUnsignedMatchingDatasetUnmarshaller(
             SecretKeyDecryptorFactory secretKeyDecryptorFactory,
-            StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer) {
+            StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer) {
         this.secretKeyDecryptorFactory = secretKeyDecryptorFactory;
         this.stringToOpenSamlObjectTransformer = stringToOpenSamlObjectTransformer;
     }
@@ -50,9 +50,10 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
             List<Attribute> attributes = attributeStatements.get(0).getAttributes();
             Optional<String> encryptedTransientSecretKey = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
             Optional<String> eidasSaml = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
-            if (encryptedTransientSecretKey.isEmpty() || eidasSaml.isEmpty()) {
+            if (!encryptedTransientSecretKey.isPresent() || !eidasSaml.isPresent()) {
                 return null;
             }
+
 
             Response response = stringToOpenSamlObjectTransformer.apply(eidasSaml.get());
             ValidatedResponse validatedResponse = new ValidatedResponse(response);

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -50,7 +50,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
             List<Attribute> attributes = attributeStatements.get(0).getAttributes();
             Optional<String> encryptedTransientSecretKey = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
             Optional<String> eidasSaml = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
-            if (!(encryptedTransientSecretKey.isPresent() && eidasSaml.isPresent())) {
+            if (encryptedTransientSecretKey.isEmpty() || eidasSaml.isEmpty()) {
                 return null;
             }
 

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -54,7 +54,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
                 return null;
             }
 
-            Response response = stringtoOpenSamlObjectTransformer.apply(eidasSaml.get());
+            Response response = stringToOpenSamlObjectTransformer.apply(eidasSaml.get());
             ValidatedResponse validatedResponse = new ValidatedResponse(response);
             Decrypter decrypter = secretKeyDecryptorFactory.createDecrypter(encryptedTransientSecretKey.get());
             Optional<EncryptedAssertion> encryptedAssertion = validatedResponse.getEncryptedAssertions().stream().findFirst();

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -1,0 +1,91 @@
+package uk.gov.ida.saml.core.transformers;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.encryption.EncryptedData;
+import org.opensaml.xmlsec.encryption.support.Decrypter;
+import org.opensaml.xmlsec.encryption.support.DecryptionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import javax.crypto.NoSuchPaddingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Optional;
+
+public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatasetUnmarshaller {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EidasUnsignedMatchingDatasetUnmarshaller.class);
+
+    private final SecretKeyDecryptorFactory secretKeyDecryptorFactory;
+    private final StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer;
+
+    public EidasUnsignedMatchingDatasetUnmarshaller(
+            SecretKeyDecryptorFactory secretKeyDecryptorFactory,
+            StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer) {
+        this.secretKeyDecryptorFactory = secretKeyDecryptorFactory;
+        this.stringtoOpenSamlObjectTransformer = stringtoOpenSamlObjectTransformer;
+    }
+
+    @Override
+    public MatchingDataset fromAssertion(Assertion assertion) {
+        List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
+        if (attributeStatements.isEmpty()) {
+            return null;
+        }
+
+        try {
+
+            List<Attribute> attributes = attributeStatements.get(0).getAttributes();
+            Optional<String> encryptedTransientSecretKey = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+            Optional<String> eidasSaml = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+            if (!(encryptedTransientSecretKey.isPresent() && eidasSaml.isPresent())) {
+                return null;
+            }
+
+            Response response = stringtoOpenSamlObjectTransformer.apply(eidasSaml.get());
+            ValidatedResponse validatedResponse = new ValidatedResponse(response);
+            Decrypter decrypter = secretKeyDecryptorFactory.createDecrypter(encryptedTransientSecretKey.get());
+            Optional<EncryptedAssertion> encryptedAssertion = validatedResponse.getEncryptedAssertions().stream().findFirst();
+            if (encryptedAssertion.isPresent()) {
+                EncryptedData encryptedData = encryptedAssertion.get().getEncryptedData();
+                return super.fromAssertion((Assertion) decrypter.decryptData(encryptedData));
+            } else {
+                LOG.warn("Error unmarshalling eIDAS unsigned assertions, encrypted assertions not present");
+            }
+
+
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | DecryptionException e) {
+            LOG.warn("Error unmarshalling eIDAS unsigned assertions from eIDAS SAML Response", e);
+        }
+        return null;
+
+    }
+
+    private Optional<String> getAttributeStringValue(List<Attribute> attributes, final String key) {
+        Optional<XMLObject> value = attributes.stream()
+                .filter(attribute -> key.equals(attribute.getName()))
+                .flatMap(attribute -> attribute.getAttributeValues().stream())
+                .findFirst();
+        String result = null;
+        if (value.isPresent()) {
+            XMLObject xmlObject = value.get();
+            result = ((StringValueSamlObject) xmlObject).getValue();
+        } else {
+            LOG.warn("Could not find unsigned assertion attribute with key " + key);
+        }
+        return Optional.ofNullable(result);
+    }
+
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -35,7 +35,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
             SecretKeyDecryptorFactory secretKeyDecryptorFactory,
             StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer) {
         this.secretKeyDecryptorFactory = secretKeyDecryptorFactory;
-        this.stringtoOpenSamlObjectTransformer = stringtoOpenSamlObjectTransformer;
+        this.stringToOpenSamlObjectTransformer = stringToOpenSamlObjectTransformer;
     }
 
     @Override

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -29,7 +29,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
     private static final Logger LOG = LoggerFactory.getLogger(EidasUnsignedMatchingDatasetUnmarshaller.class);
 
     private final SecretKeyDecryptorFactory secretKeyDecryptorFactory;
-    private final StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer;
+    private final StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer;
 
     public EidasUnsignedMatchingDatasetUnmarshaller(
             SecretKeyDecryptorFactory secretKeyDecryptorFactory,

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyDecryptorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyDecryptorFactory.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.security;
+
+import org.bouncycastle.util.encoders.Base64;
+import org.opensaml.security.credential.BasicCredential;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.support.Decrypter;
+import org.opensaml.xmlsec.keyinfo.impl.StaticKeyInfoCredentialResolver;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.util.List;
+
+import static javax.crypto.Cipher.SECRET_KEY;
+
+public class SecretKeyDecryptorFactory {
+
+    private final IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever;
+
+    public SecretKeyDecryptorFactory(IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever) {
+        this.idaKeyStoreCredentialRetriever = idaKeyStoreCredentialRetriever;
+    }
+
+    public Decrypter createDecrypter(String encryptedSecretKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException {
+        List<Credential> decryptingCredentials = idaKeyStoreCredentialRetriever.getDecryptingCredentials();
+        PrivateKey privateKey = decryptingCredentials.get(0).getPrivateKey();
+        Cipher cipher = Cipher.getInstance(privateKey.getAlgorithm());
+        cipher.init(Cipher.UNWRAP_MODE, privateKey);
+        SecretKey transientKey = (SecretKey) cipher.unwrap(Base64.decode(encryptedSecretKey), cipher.getAlgorithm(), SECRET_KEY);
+        BasicCredential basicCredential = new BasicCredential(transientKey);
+        StaticKeyInfoCredentialResolver keyResolver = new StaticKeyInfoCredentialResolver(basicCredential);
+        return new Decrypter(keyResolver, null, null);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
@@ -1,0 +1,161 @@
+package uk.gov.ida.saml.core.transformers;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.encryption.EncryptedData;
+import org.opensaml.xmlsec.encryption.support.Decrypter;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
+import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EidasUnsignedMatchingDatasetUnmarshallerTest {
+
+    @InjectMocks
+    private EidasUnsignedMatchingDatasetUnmarshaller unmarshaller;
+
+    @Mock
+    private SecretKeyDecryptorFactory secretKeyDecryptorFactory;
+
+    @Mock
+    private StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer;
+
+    @Mock
+    private Assertion unsignedAssertion;
+
+    @Mock
+    private Assertion eidasAssertion;
+
+    @Mock
+    private AttributeStatement unsignedAttributeStatement;
+
+    @Mock
+    private AttributeStatement eidasAttributeStatement;
+
+    @Mock
+    private Attribute attributeEncryptionKeys;
+
+    @Mock
+    private Attribute firstName;
+
+    @Mock
+    private Attribute pid;
+
+    @Mock
+    private Attribute attributeEidasResponse;
+
+    @Mock
+    private StringValueSamlObject attributeValueEncryptionKeys;
+
+    @Mock
+    private StringValueSamlObject attributeValueEidasResponse;
+
+    @Mock
+    private PersonIdentifier personIdentifierValue;
+
+    @Mock
+    private CurrentGivenName firstNameValue;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private Decrypter decrypter;
+
+    @Mock
+    private EncryptedAssertion encryptedAssertion;
+
+    @Mock
+    private EncryptedData encryptedData;
+
+    @Test
+    public void whenAssertionHasNoAttributeStatementsThenMatchingDatasetIsNull() {
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(unsignedAssertion);
+        assertThat(matchingDataset).isNull();
+        verify(unsignedAssertion).getAttributeStatements();
+        verifyZeroInteractions(stringtoOpenSamlObjectTransformer, secretKeyDecryptorFactory);
+    }
+
+    @Test
+    public void whenNoEncryptionKeysAttributeThenMatchingDatasetIsNull() {
+        when(unsignedAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(unsignedAttributeStatement));
+        when(unsignedAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(attributeEncryptionKeys, attributeEidasResponse));
+        when(attributeEncryptionKeys.getName()).thenReturn("no matching key");
+        when(attributeEidasResponse.getName()).thenReturn(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(unsignedAssertion);
+        assertThat(matchingDataset).isNull();
+        verify(attributeEncryptionKeys, times(2)).getName();
+        verify(attributeEidasResponse, times(2)).getName();
+        verify(attributeEidasResponse).getAttributeValues();
+        verifyNoMoreInteractions(attributeEncryptionKeys, attributeEidasResponse);
+        verifyZeroInteractions(stringtoOpenSamlObjectTransformer, secretKeyDecryptorFactory);
+    }
+
+    @Test
+    public void whenNoEidasResponseAttributeThenMatchingDatasetIsNull() {
+        when(unsignedAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(unsignedAttributeStatement));
+        when(unsignedAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(attributeEncryptionKeys, attributeEidasResponse));
+        when(attributeEncryptionKeys.getName()).thenReturn(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+        when(attributeEidasResponse.getName()).thenReturn("no matching key");
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(unsignedAssertion);
+        assertThat(matchingDataset).isNull();
+        verify(attributeEncryptionKeys, times(2)).getName();
+        verify(attributeEidasResponse, times(2)).getName();
+        verify(attributeEncryptionKeys).getAttributeValues();
+        verifyNoMoreInteractions(attributeEncryptionKeys, attributeEidasResponse);
+        verifyZeroInteractions(stringtoOpenSamlObjectTransformer, secretKeyDecryptorFactory);
+    }
+
+    @Test
+    public void shouldDelegateToMatchingDatasetUnmarshallerToUnpackEidasAssertions() throws Exception {
+
+        when(unsignedAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(unsignedAttributeStatement));
+        when(eidasAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(eidasAttributeStatement));
+        when(unsignedAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(attributeEncryptionKeys, attributeEidasResponse));
+        when(eidasAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(firstName, pid));
+        when(attributeEncryptionKeys.getName()).thenReturn(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+        when(attributeEidasResponse.getName()).thenReturn(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+        when(firstName.getName()).thenReturn(IdaConstants.Eidas_Attributes.FirstName.NAME);
+        when(pid.getName()).thenReturn(IdaConstants.Eidas_Attributes.PersonIdentifier.NAME);
+        when(attributeEncryptionKeys.getAttributeValues()).thenReturn(ImmutableList.of(attributeValueEncryptionKeys));
+        when(attributeEidasResponse.getAttributeValues()).thenReturn(ImmutableList.of(attributeValueEidasResponse));
+        when(firstName.getAttributeValues()).thenReturn(ImmutableList.of(firstNameValue));
+        when(firstNameValue.isLatinScript()).thenReturn(true);
+        when(pid.getAttributeValues()).thenReturn(ImmutableList.of(personIdentifierValue));
+        when(personIdentifierValue.getPersonIdentifier()).thenReturn("It's a me, Mario");
+        when(attributeValueEncryptionKeys.getValue()).thenReturn("an encrypted  key string");
+        when(attributeValueEidasResponse.getValue()).thenReturn("an eidas response string");
+        when(stringtoOpenSamlObjectTransformer.apply("an eidas response string")).thenReturn(response);
+        when(secretKeyDecryptorFactory.createDecrypter("an encrypted  key string")).thenReturn(decrypter);
+        when(response.getEncryptedAssertions()).thenReturn(ImmutableList.of(encryptedAssertion));
+        when(encryptedAssertion.getEncryptedData()).thenReturn(encryptedData);
+        when(decrypter.decryptData(encryptedData)).thenReturn(eidasAssertion);
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(unsignedAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        verify(firstNameValue).getFirstName();
+        verify(personIdentifierValue).getPersonIdentifier();
+    }
+
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyDecryptorFactoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/SecretKeyDecryptorFactoryTest.java
@@ -1,0 +1,67 @@
+package uk.gov.ida.saml.security;
+
+import com.google.common.collect.ImmutableList;
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.opensaml.security.credential.Credential;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.security.saml.TestCredentialFactory;
+
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SecretKeyDecryptorFactoryTest {
+
+    private Credential credential = new TestCredentialFactory(
+            TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT,
+            TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY)
+            .getEncryptionKeyPair();
+
+
+    @InjectMocks
+    private SecretKeyDecryptorFactory factory;
+
+    @Mock
+    private IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever;
+
+    @Mock
+    private Credential encryptionCredentials;
+
+    @Test
+    public void shouldCreateDecreypterUsingPrivateKey() throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException {
+        SecretKey secretKey = createSecretKey();
+        String encryptedSecretKey = encryptSecretKeyWithCredentialsPublicKey(secretKey);
+        when(idaKeyStoreCredentialRetriever.getDecryptingCredentials()).thenReturn(ImmutableList.of(encryptionCredentials));
+        when(encryptionCredentials.getPrivateKey()).thenReturn(credential.getPrivateKey());
+        factory.createDecrypter(encryptedSecretKey);
+        verify(idaKeyStoreCredentialRetriever).getDecryptingCredentials();
+        verify(encryptionCredentials).getPrivateKey();
+    }
+
+    private String encryptSecretKeyWithCredentialsPublicKey(SecretKey secretKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException {
+        PublicKey publicKey = credential.getPublicKey();
+        Cipher cipher = Cipher.getInstance(publicKey.getAlgorithm());
+        cipher.init(Cipher.WRAP_MODE, publicKey);
+        return Base64.toBase64String(cipher.wrap(secretKey));
+    }
+
+    private SecretKey createSecretKey() throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("DES");
+        keyGenerator.init(56);
+        return keyGenerator.generateKey();
+    }
+}


### PR DESCRIPTION
Some EU Member States send unsigned SAML assertions from their Proxy Nodes.

The Verify Hub expects all assertions to be signed -  a [previous PR](https://github.com/alphagov/verify-saml-libs/pull/86) addresses this, by encrypting the ephemeral secret keys used to decrypt the assertions, using the service's public encryption key.

This PR will allow a Government Service to decrypt these assertions using its private encryption key. This code will be used by the [matching-service-adapter](https://github.com/alphagov/verify-matching-service-adapter) in a subsequent PR.

The key concept in this PR is that unsigned assertions will be first decrypted using the `EidasUnsignedMatchingDatasetUnmarshaller` and the actual creation of a `MatchingDataSet` will be delegated to the BAU `EidasMatchingDatasetUnmarshaller`, which it extends.

The creation of a`Decrypter` for decryption of the secret keys is handled by `SecretKeyDecryptorFactory`, which has this distinct responsibility so that it can be re-used in the `VSP`.