### PR TITLE
EID-1683 move AudienceRestrictionValidator to saml-lib

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/SamlResponseValidationException.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/SamlResponseValidationException.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.saml.core.validation;
+
+public class SamlResponseValidationException extends RuntimeException {
+
+    public SamlResponseValidationException(String msg) {
+        super(msg);
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/conditions/AudienceRestrictionValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/conditions/AudienceRestrictionValidator.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.saml.core.validation.conditions;
+
+import com.google.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
+import org.opensaml.saml.saml2.core.Audience;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AudienceRestrictionValidator {
+    @Inject
+    public AudienceRestrictionValidator() {
+    }
+
+    public void validate(List<AudienceRestriction> audienceRestrictions, String... acceptableEntityIds) {
+        if (audienceRestrictions == null || audienceRestrictions.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one audience restriction is expected.");
+        }
+
+        List<Audience> audiences = audienceRestrictions.get(0).getAudiences();
+        if (audiences == null || audiences.size() != 1) {
+            throw new SamlResponseValidationException("Exactly one audience is expected.");
+        }
+
+        String audience = audiences.get(0).getAudienceURI();
+        if (Arrays.stream(acceptableEntityIds).noneMatch(s -> s.equals(audience))) {
+            throw new SamlResponseValidationException(String.format(
+                "Audience must match an acceptable entity ID. Acceptable entity IDs are: %s but audience was: %s",
+                StringUtils.join(acceptableEntityIds, ", "),
+                audience));
+        }
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.saml.core.validators.conditions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static junit.framework.TestCase.fail;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AudienceRestrictionValidatorMultipleEntityIdTests {
+
+    private AudienceRestrictionValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AudienceRestrictionValidator();
+    }
+
+    @Test
+    public void audienceRestrictionValidatorShouldAcceptOnlyOneAudienceRestriction() {
+        List<AudienceRestriction> restrictions = new LinkedList<>();
+        String[] acceptableAudiences = new String[] { "audience1", "audience2" };
+
+        restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience1").build());
+
+        try {
+            validator.validate(restrictions, acceptableAudiences);
+        } catch (Exception e) {
+            fail("Should not fail validation with a single audience restriction.");
+        }
+
+        restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience2").build());
+
+        try {
+            validator.validate(restrictions, acceptableAudiences);
+            fail("Should not pass validation with more than 1 audience restriction.");
+        } catch (SamlResponseValidationException e) {
+            assertEquals(e.getMessage(), "Exactly one audience restriction is expected.");
+        }
+    }
+
+    @Test
+    public void audienceRestrictionValidatorShouldMatchOnAcceptableEntityIds() {
+        List<AudienceRestriction> restrictions = new LinkedList<>();
+        String[] acceptableAudiences = new String[] { "audience1", "audience2" };
+        String[] unacceptableAudiences = new String[] { "audience2" };
+
+        restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience1").build());
+
+        try {
+            validator.validate(restrictions, unacceptableAudiences);
+            fail("Should not pass validation when the audience is not found amongst the restrictions.");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Audience must match an acceptable entity ID."));
+        }
+
+        try {
+            validator.validate(restrictions, acceptableAudiences);
+        } catch (SamlResponseValidationException e) {
+            fail("Should pass validation when the audience is found amongst the restrictions.");
+        }
+    }
+
+}
+

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
@@ -1,9 +1,7 @@
 package uk.gov.ida.saml.core.validators.conditions;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.opensaml.saml.saml2.core.AudienceRestriction;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
@@ -14,14 +12,12 @@ import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @RunWith(OpenSAMLMockitoRunner.class)
 public class AudienceRestrictionValidatorMultipleEntityIdTests {
 
     private AudienceRestrictionValidator validator;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
 
     @Before
     public void setUp() {
@@ -44,10 +40,11 @@ public class AudienceRestrictionValidatorMultipleEntityIdTests {
         restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience1").build());
         restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience2").build());
 
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one audience restriction is expected.");
-
-        validator.validate(restrictions, acceptableAudiences);
+        assertThatThrownBy(() -> {
+                validator.validate(restrictions, acceptableAudiences);
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Exactly one audience restriction is expected.");
     }
 
     @Test
@@ -56,9 +53,11 @@ public class AudienceRestrictionValidatorMultipleEntityIdTests {
         List<AudienceRestriction> restrictions = new LinkedList<>();
         restrictions.add(AudienceRestrictionBuilder.anAudienceRestriction().withAudienceId("audience1").build());
 
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Audience must match an acceptable entity ID.");
-        validator.validate(restrictions, unacceptableAudiences);
+        assertThatThrownBy(() -> {
+                validator.validate(restrictions, unacceptableAudiences);
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Audience must match an acceptable entity ID.");
     }
 
     @Test

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorMultipleEntityIdTests.java
@@ -22,7 +22,7 @@ public class AudienceRestrictionValidatorMultipleEntityIdTests {
     private AudienceRestrictionValidator validator;
 
     @Before
-    public void setup() {
+    public void setUp() {
         validator = new AudienceRestrictionValidator();
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorTest.java
@@ -2,9 +2,7 @@ package uk.gov.ida.saml.core.validators.conditions;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Answers;
 import org.opensaml.saml.saml2.core.Audience;
 import org.opensaml.saml.saml2.core.AudienceRestriction;
@@ -15,6 +13,7 @@ import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAudienceRestriction;
@@ -22,9 +21,6 @@ import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAu
 public class AudienceRestrictionValidatorTest {
 
     private AudienceRestrictionValidator validator;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -45,24 +41,27 @@ public class AudienceRestrictionValidatorTest {
 
     @Test
     public void shouldThrowExceptionWhenAudienceRestrictionsIsNull() {
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one audience restriction is expected.");
-
         List<AudienceRestriction> audienceRestrictions = null;
-        validator.validate(audienceRestrictions, "any-entity-id");
+
+        assertThatThrownBy(() -> {
+                validator.validate(audienceRestrictions, "any-entity-id");
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Exactly one audience restriction is expected.");
     }
 
     @Test
     public void shouldThrowExceptionWhenAudienceRestrictionsHasMoreThanOneElements() {
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one audience restriction is expected.");
-
         List<AudienceRestriction> audienceRestrictions = ImmutableList.of(
             anAudienceRestriction().build(),
             anAudienceRestriction().build()
         );
 
-        validator.validate(audienceRestrictions, "any-entity-id");
+        assertThatThrownBy(() -> {
+                validator.validate(audienceRestrictions, "any-entity-id");
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Exactly one audience restriction is expected.");
     }
 
     @Test
@@ -70,10 +69,11 @@ public class AudienceRestrictionValidatorTest {
         AudienceRestriction audienceRestriction = mock(AudienceRestriction.class, Answers.RETURNS_DEEP_STUBS);
         when(audienceRestriction.getAudiences()).thenReturn(null);
 
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one audience is expected.");
-
-        validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+        assertThatThrownBy(() -> {
+                validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Exactly one audience is expected.");
     }
 
     @Test
@@ -82,10 +82,11 @@ public class AudienceRestrictionValidatorTest {
         audienceRestriction.getAudiences().add(new AudienceBuilder().buildObject());
         audienceRestriction.getAudiences().add(new AudienceBuilder().buildObject());
 
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage("Exactly one audience is expected.");
-
-        validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+        assertThatThrownBy(() -> {
+                validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+            })
+            .isInstanceOf(SamlResponseValidationException.class)
+            .hasMessageContaining("Exactly one audience is expected.");
     }
 
     @Test
@@ -96,9 +97,13 @@ public class AudienceRestrictionValidatorTest {
         AudienceRestriction audienceRestriction = mock(AudienceRestriction.class, Answers.RETURNS_DEEP_STUBS);
         when(audienceRestriction.getAudiences()).thenReturn(ImmutableList.of(audience));
 
-        expectedException.expect(SamlResponseValidationException.class);
-        expectedException.expectMessage(String.format("Audience must match an acceptable entity ID. Acceptable entity IDs are: %s but audience was: %s", "unknown-entity-id", "some-entity-id"));
-
-        validator.validate(ImmutableList.of(audienceRestriction), "unknown-entity-id");
+        assertThatThrownBy(() -> {
+                validator.validate(ImmutableList.of(audienceRestriction), "unknown-entity-id");
+            })
+        .isInstanceOf(SamlResponseValidationException.class)
+        .hasMessageContaining(String.format(
+            "Audience must match an acceptable entity ID. Acceptable entity IDs are: %s but audience was: %s",
+            "unknown-entity-id",
+            "some-entity-id"));
     }
 }

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validators/conditions/AudienceRestrictionValidatorTest.java
@@ -1,0 +1,104 @@
+package uk.gov.ida.saml.core.validators.conditions;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.opensaml.saml.saml2.core.Audience;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.impl.AudienceBuilder;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.validation.SamlResponseValidationException;
+import uk.gov.ida.saml.core.validation.conditions.AudienceRestrictionValidator;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAudienceRestriction;
+
+public class AudienceRestrictionValidatorTest {
+
+    private AudienceRestrictionValidator validator;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        validator = new AudienceRestrictionValidator();
+        IdaSamlBootstrap.bootstrap();
+    }
+
+    @Test
+    public void shouldNotComplainWhenCorrectDataIsPassed() {
+        Audience audience = new AudienceBuilder().buildObject();
+        audience.setAudienceURI("some-entity-id");
+
+        AudienceRestriction audienceRestriction = mock(AudienceRestriction.class, Answers.RETURNS_DEEP_STUBS);
+        when(audienceRestriction.getAudiences()).thenReturn(ImmutableList.of(audience));
+
+        validator.validate(ImmutableList.of(audienceRestriction), "some-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAudienceRestrictionsIsNull() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Exactly one audience restriction is expected.");
+
+        List<AudienceRestriction> audienceRestrictions = null;
+        validator.validate(audienceRestrictions, "any-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAudienceRestrictionsHasMoreThanOneElements() {
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Exactly one audience restriction is expected.");
+
+        List<AudienceRestriction> audienceRestrictions = ImmutableList.of(
+            anAudienceRestriction().build(),
+            anAudienceRestriction().build()
+        );
+
+        validator.validate(audienceRestrictions, "any-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAudiencesIsNull() {
+        AudienceRestriction audienceRestriction = mock(AudienceRestriction.class, Answers.RETURNS_DEEP_STUBS);
+        when(audienceRestriction.getAudiences()).thenReturn(null);
+
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Exactly one audience is expected.");
+
+        validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAudiencesIsMoreThanOne() {
+        AudienceRestriction audienceRestriction = anAudienceRestriction().build();
+        audienceRestriction.getAudiences().add(new AudienceBuilder().buildObject());
+        audienceRestriction.getAudiences().add(new AudienceBuilder().buildObject());
+
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage("Exactly one audience is expected.");
+
+        validator.validate(ImmutableList.of(audienceRestriction), "any-entity-id");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAudienceUriDoesNotMatchTheEntityId() {
+        Audience audience = new AudienceBuilder().buildObject();
+        audience.setAudienceURI("some-entity-id");
+
+        AudienceRestriction audienceRestriction = mock(AudienceRestriction.class, Answers.RETURNS_DEEP_STUBS);
+        when(audienceRestriction.getAudiences()).thenReturn(ImmutableList.of(audience));
+
+        expectedException.expect(SamlResponseValidationException.class);
+        expectedException.expectMessage(String.format("Audience must match an acceptable entity ID. Acceptable entity IDs are: %s but audience was: %s", "unknown-entity-id", "some-entity-id"));
+
+        validator.validate(ImmutableList.of(audienceRestriction), "unknown-entity-id");
+    }
+}


### PR DESCRIPTION
This PR is part 1 of ~4 PRs that will form EID-1683. It:

- ...moves the `AudienceRestrictionValidator` into `verify-saml-libs`.
- ...updates the `AudienceRestrictionValidator` to accept 1 or more acceptable Entity Ids.
- ...changes behaviour of the `AudienceRestrictionValidator` to match against _any_ acceptable Entity Ids, falling back to default behaviour when only 1 is provided.

Subsequent PRs will:

- Adapt the MSA to accept more than 1 acceptable Entity Id through configuration, and use the new AudienceRestrictionValidator from saml-lib to validate the AudienceRestrictions in SAML Assertions (gracefully falling back to default behaviour if new configuration is not available).
- Adapt the VSP to accept more than 1 acceptable Entity Id through configuration, and use the new AudienceRestrictionValidator from saml-lib to validate the AudienceRestrictions in SAML Assertions (gracefully falling back to default behaviour if new configuration is not available).
- Update the configuration to provide a set of acceptable EntityIds.