### PR TITLE
EID-1666 Create string transformer that doesn't encrypt assertions

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/api/CoreTransformersFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/api/CoreTransformersFactory.java
@@ -8,6 +8,7 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.transformers.inbound.Cycle3DatasetFactory;
 import uk.gov.ida.saml.core.transformers.inbound.HubAssertionUnmarshaller;
 import uk.gov.ida.saml.core.transformers.outbound.ResponseToSignedStringTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.ResponseToSignedStringWithUnEncryptedAssertionsTransformer;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
@@ -134,6 +135,20 @@ public class CoreTransformersFactory {
             final DigestAlgorithm digestAlgorithm) {
         SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
         return getResponseStringTransformer(publicKeyStore, entityToEncryptForLocator, new EncrypterFactory(), signatureFactory, responseAssertionSigner);
+    }
+
+    public ResponseToSignedStringWithUnEncryptedAssertionsTransformer getResponseStringTransformer(
+            final IdaKeyStore keyStore,
+            final ResponseAssertionSigner responseAssertionSigner,
+            final SignatureAlgorithm signatureAlgorithm,
+            final DigestAlgorithm digestAlgorithm) {
+        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
+        return new ResponseToSignedStringWithUnEncryptedAssertionsTransformer(
+                new XmlObjectToBase64EncodedStringTransformer<>(),
+                new SamlSignatureSigner<>(),
+                responseAssertionSigner,
+                new ResponseSignatureCreator(signatureFactory)
+        );
     }
 
     private ResponseToSignedStringTransformer getResponseStringTransformer(

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/EncryptedAssertionKeys.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/EncryptedAssertionKeys.java
@@ -15,6 +15,5 @@ public interface EncryptedAssertionKeys extends AttributeValue {
 
     String getEncryptedAssertionKeys();
 
-    void setEncryptedAssertionKeys(String countrySamlResponse);
-
+    void setEncryptedAssertionKeys(String encryptedAssertionKey);
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/outbound/ResponseToSignedStringWithUnEncryptedAssertionsTransformer.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/outbound/ResponseToSignedStringWithUnEncryptedAssertionsTransformer.java
@@ -1,0 +1,39 @@
+package uk.gov.ida.saml.core.transformers.outbound;
+
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import javax.inject.Inject;
+import java.util.function.Function;
+
+public class ResponseToSignedStringWithUnEncryptedAssertionsTransformer implements Function<Response, String> {
+    protected final XmlObjectToBase64EncodedStringTransformer<?> xmlObjectToBase64EncodedStringTransformer;
+    protected final SamlSignatureSigner<Response> samlSignatureSigner;
+    protected final ResponseAssertionSigner responseAssertionSigner;
+    protected final ResponseSignatureCreator responseSignatureCreator;
+
+    @Inject
+    public ResponseToSignedStringWithUnEncryptedAssertionsTransformer(
+            XmlObjectToBase64EncodedStringTransformer<?> xmlObjectToBase64EncodedStringTransformer,
+            SamlSignatureSigner<Response> samlSignatureSigner,
+            ResponseAssertionSigner responseAssertionSigner,
+            ResponseSignatureCreator responseSignatureCreator) {
+        this.xmlObjectToBase64EncodedStringTransformer = xmlObjectToBase64EncodedStringTransformer;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.responseAssertionSigner = responseAssertionSigner;
+        this.responseSignatureCreator = responseSignatureCreator;
+    }
+
+    @Override
+    public String apply(final Response response) {
+        final Response responseWithSignature = responseSignatureCreator.addUnsignedSignatureTo(response);
+        final Response assertionSignedResponse = responseAssertionSigner.signAssertions(responseWithSignature);
+        final Response signedResponse = samlSignatureSigner.sign(assertionSignedResponse);
+
+        return xmlObjectToBase64EncodedStringTransformer.apply(signedResponse);
+    }
+}
+

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/ResponseToSignedStringWithUnEncryptedAssertionsTransformerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/outbound/ResponseToSignedStringWithUnEncryptedAssertionsTransformerTest.java
@@ -1,0 +1,79 @@
+package uk.gov.ida.saml.core.transformers.outbound;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.PrivateKeyStoreFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.deserializers.validators.Base64StringDecoder;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.SignatureFactory;
+import uk.gov.ida.saml.security.saml.deserializers.SamlObjectParser;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.aCountryResponseAssertion;
+import static uk.gov.ida.saml.security.saml.builders.ResponseBuilder.aResponseWithNoEncryptedAssertions;
+import static uk.gov.ida.shared.utils.string.StringEncoding.toBase64Encoded;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class ResponseToSignedStringWithUnEncryptedAssertionsTransformerTest {
+    @Mock
+    private IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever;
+
+    @Test
+    public void shouldSignResponseAndAssertionsAndBase64Encode() throws Exception {
+        SignatureFactory signatureFactory = new SignatureFactory(
+                keyStoreCredentialRetriever,
+                new SignatureRSASHA256(),
+                new DigestSHA256()
+        );
+        Credential hubSigningCredential = createHubSigningCredential();
+        when(keyStoreCredentialRetriever.getSigningCredential()).thenReturn(hubSigningCredential);
+
+        ResponseToSignedStringWithUnEncryptedAssertionsTransformer transformer = new ResponseToSignedStringWithUnEncryptedAssertionsTransformer(
+                new XmlObjectToBase64EncodedStringTransformer<>(),
+                new SamlSignatureSigner<>(),
+                new ResponseAssertionSigner(signatureFactory),
+                new ResponseSignatureCreator(signatureFactory)
+        );
+
+        Response response = aResponseWithNoEncryptedAssertions()
+                .addAssertion(aCountryResponseAssertion().buildUnencrypted())
+                .build();
+
+        String base64TransformedResponse = transformer.apply(response);
+
+        String decodedResponse = new Base64StringDecoder().decode(base64TransformedResponse);
+        Response signedResponse = (Response) new SamlObjectParser().getSamlObject(decodedResponse);
+
+        CountrySamlResponse countrySamlResponseValue = (CountrySamlResponse) signedResponse.getAssertions().get(0).getAttributeStatements().get(0).getAttributes().get(0).getAttributeValues().get(0);
+        EncryptedAssertionKeys encryptedAssertionKeys = (EncryptedAssertionKeys) signedResponse.getAssertions().get(0).getAttributeStatements().get(0).getAttributes().get(1).getAttributeValues().get(0);
+        
+        assertThat(countrySamlResponseValue.getCountrySamlResponse()).isEqualTo("base64SamlResponse");
+        assertThat(encryptedAssertionKeys.getEncryptedAssertionKeys()).isEqualTo("base64EncryptedAssertionKey");
+        assertThat(signedResponse.getSignature()).isNotNull();
+        assertThat(signedResponse.getAssertions().get(0).getSignature()).isNotNull();
+    }
+
+
+    private Credential createHubSigningCredential() {
+        return new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT, toBase64Encoded(
+                new PrivateKeyStoreFactory().create(TestEntityIds.HUB_ENTITY_ID).getSigningPrivateKey()
+                        .getEncoded()
+        )).getSigningCredential();
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/saml/builders/ResponseBuilder.java
@@ -100,6 +100,11 @@ public class ResponseBuilder {
         return this;
     }
 
+    public ResponseBuilder addAssertion(Assertion assertion) {
+        this.assertions.add(assertion);
+        return this;
+    }
+
     public ResponseBuilder addEncryptedAssertion(EncryptedAssertion encryptedAssertion) {
         addDefaultEncryptedAssertionIfNoneIsAdded = false;
         this.encryptedAssertions.add(encryptedAssertion);

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionBuilder.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionBuilder.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Throwables.propagate;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_CONNECTOR_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
 import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anEidasAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.aCountryResponseAttributeStatement;
 import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anEidasAuthnStatement;
 import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
 import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
@@ -80,6 +81,16 @@ public class AssertionBuilder {
                         .withSubjectConfirmationData(aSubjectConfirmationData().withRecipient(HUB_CONNECTOR_ENTITY_ID).build())
                         .build())
                     .build());
+    }
+
+    public static AssertionBuilder aCountryResponseAssertion() {
+        return anAssertion()
+                .withIssuer(
+                        new IssuerBuilder()
+                        .withIssuerId(TestEntityIds.HUB_ENTITY_ID)
+                        .build())
+                .addAttributeStatement(aCountryResponseAttributeStatement().build())
+                .withoutSigning();
     }
 
     public static AssertionBuilder anAuthnStatementAssertion() {

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeStatementBuilder.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeStatementBuilder.java
@@ -4,13 +4,17 @@ import org.joda.time.LocalDate;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
 import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
 import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
 import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
+import uk.gov.ida.saml.core.extensions.eidas.impl.CountrySamlResponseBuilder;
 import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentFamilyNameBuilder;
 import uk.gov.ida.saml.core.extensions.eidas.impl.CurrentGivenNameBuilder;
 import uk.gov.ida.saml.core.extensions.eidas.impl.DateOfBirthBuilder;
+import uk.gov.ida.saml.core.extensions.eidas.impl.EncryptedAssertionKeysBuilder;
 import uk.gov.ida.saml.core.extensions.eidas.impl.PersonIdentifierBuilder;
 import uk.gov.ida.saml.core.test.OpenSamlXmlObjectFactory;
 
@@ -27,7 +31,7 @@ public class AttributeStatementBuilder {
     }
 
     public static AttributeStatementBuilder anEidasAttributeStatement() {
-        Attribute firstName =  anAttribute(IdaConstants.Eidas_Attributes.FirstName.NAME);
+        Attribute firstName = anAttribute(IdaConstants.Eidas_Attributes.FirstName.NAME);
         CurrentGivenName firstNameValue = new CurrentGivenNameBuilder().buildObject();
         firstNameValue.setFirstName("Joe");
         firstName.getAttributeValues().add(firstNameValue);
@@ -52,6 +56,22 @@ public class AttributeStatementBuilder {
             .addAttribute(familyName)
             .addAttribute(personIdentifier)
             .addAttribute(dateOfBirth);
+    }
+
+    public static AttributeStatementBuilder aCountryResponseAttributeStatement() {
+        Attribute countrySamlResponse = anAttribute(IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+        CountrySamlResponse countrySamlResponseValue = new CountrySamlResponseBuilder().buildObject();
+        countrySamlResponseValue.setCountrySamlResponse("base64SamlResponse");
+        countrySamlResponse.getAttributeValues().add(countrySamlResponseValue);
+
+        Attribute encryptedAssertionKeys = anAttribute(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+        EncryptedAssertionKeys encryptedAssertionKeysValue = new EncryptedAssertionKeysBuilder().buildObject();
+        encryptedAssertionKeysValue.setEncryptedAssertionKeys("base64EncryptedAssertionKey");
+        encryptedAssertionKeys.getAttributeValues().add(encryptedAssertionKeysValue);
+
+        return anAttributeStatement()
+                .addAttribute(countrySamlResponse)
+                .addAttribute(encryptedAssertionKeys);
     }
 
     private static Attribute anAttribute(String name) {


### PR DESCRIPTION
This is for use when returning a Response from saml-engine that wraps an
eIDAS countries SAML response and their encrypted keys. All the
sensitive data is already encrypted so we don't need to encrypt it
again.