### PR TITLE
EID-1604 - Use EncryptionCredentialResolver as type for credentialFactory in SecretKeyEncrypter

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/SecretKeyEncrypter.java
@@ -15,9 +15,9 @@ import static uk.gov.ida.saml.security.errors.SamlTransformationErrorFactory.una
 
 public class SecretKeyEncrypter {
 
-    private KeyStoreBackedEncryptionCredentialResolver credentialFactory;
+    private EncryptionCredentialResolver credentialFactory;
 
-    public SecretKeyEncrypter(KeyStoreBackedEncryptionCredentialResolver credentialFactory) {
+    public SecretKeyEncrypter(EncryptionCredentialResolver credentialFactory) {
         this.credentialFactory = credentialFactory;
     }
 


### PR DESCRIPTION
Update the type of `credentialFactory` field in `SecretKeyEncrypter` to be the interface `EncryptionCredentialResolver`. 

This will allow the **MSA** to construct a `SecretKeyEncrypter` with the `MetadataBackedEncryptionCredentialResolver` implementation.

The `SecretKeyEncrypter` is used by both `saml-engine` and `MSA` to encrypt and decrypt secret keys.

The Hub uses a `KeyStoreBackedEncryptionCredentialResolver` implementation of `EncryptionCredentialResolver` - this has been tested with the change proposed.