### PR TITLE
Make it easier to read values from eidas unsigned assertion attributes

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/CountrySamlResponse.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/CountrySamlResponse.java
@@ -1,19 +1,13 @@
 package uk.gov.ida.saml.core.extensions.eidas;
 
 import org.opensaml.saml.common.xml.SAMLConstants;
-import org.opensaml.saml.saml2.core.AttributeValue;
 import uk.gov.ida.saml.core.IdaConstants;
 
 import javax.xml.namespace.QName;
 
-public interface CountrySamlResponse extends AttributeValue {
+public interface CountrySamlResponse extends UnsignedAssertionAttributeValue {
     String DEFAULT_ELEMENT_LOCAL_NAME = "AttributeValue";
     QName DEFAULT_ELEMENT_NAME = new QName(SAMLConstants.SAML20_NS, DEFAULT_ELEMENT_LOCAL_NAME, SAMLConstants.SAML20_PREFIX);
     String TYPE_LOCAL_NAME = "CountrySamlResponseType";
     QName TYPE_NAME = new QName(IdaConstants.IDA_NS, TYPE_LOCAL_NAME, IdaConstants.IDA_PREFIX);
-
-
-    String getCountrySamlResponse();
-
-    void setCountrySamlResponse(String countrySamlResponse);
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/EncryptedAssertionKeys.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/EncryptedAssertionKeys.java
@@ -1,20 +1,14 @@
 package uk.gov.ida.saml.core.extensions.eidas;
 
 import org.opensaml.saml.common.xml.SAMLConstants;
-import org.opensaml.saml.saml2.core.AttributeValue;
 import uk.gov.ida.saml.core.IdaConstants;
 
 import javax.xml.namespace.QName;
 
 
-public interface EncryptedAssertionKeys extends AttributeValue {
+public interface EncryptedAssertionKeys extends UnsignedAssertionAttributeValue {
     String DEFAULT_ELEMENT_LOCAL_NAME = "AttributeValue";
     QName DEFAULT_ELEMENT_NAME = new QName(SAMLConstants.SAML20_NS, DEFAULT_ELEMENT_LOCAL_NAME, SAMLConstants.SAML20_PREFIX);
     String TYPE_LOCAL_NAME = "EncryptedAssertionKeysType";
     QName TYPE_NAME = new QName(IdaConstants.IDA_NS, TYPE_LOCAL_NAME, IdaConstants.IDA_PREFIX);
-
-    String getEncryptedAssertionKeys();
-
-    void setEncryptedAssertionKeys(String countrySamlResponse);
-
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/UnsignedAssertionAttributeValue.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/UnsignedAssertionAttributeValue.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.saml.core.extensions.eidas;
+
+import org.opensaml.saml.saml2.core.AttributeValue;
+
+public interface UnsignedAssertionAttributeValue extends AttributeValue {
+    void setValue(String value);
+    String getValue();
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseImpl.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseImpl.java
@@ -14,13 +14,19 @@ public class CountrySamlResponseImpl extends AbstractSAMLObject implements Count
         super(namespaceURI, elementLocalName, namespacePrefix);
     }
 
-    public String getCountrySamlResponse() { return countrySamlResponse; }
+    @Override
+    public String getValue() {
+        return countrySamlResponse;
+    }
 
-    public void setCountrySamlResponse(String s) {
-        countrySamlResponse = prepareForAssignment(countrySamlResponse, s);
+    @Override
+    public void setValue(String value) {
+        countrySamlResponse = prepareForAssignment(countrySamlResponse, value);
     }
 
     @Nullable
     @Override
-    public List<XMLObject> getOrderedChildren() { return null; }
+    public List<XMLObject> getOrderedChildren() {
+        return null;
+    }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseMarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseMarshaller.java
@@ -2,7 +2,6 @@ package uk.gov.ida.saml.core.extensions.eidas.impl;
 
 import net.shibboleth.utilities.java.support.xml.ElementSupport;
 import org.opensaml.core.xml.XMLObject;
-import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.common.AbstractSAMLObjectMarshaller;
 import org.w3c.dom.Element;
 import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
@@ -11,8 +10,8 @@ import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
 public class CountrySamlResponseMarshaller extends AbstractSAMLObjectMarshaller {
 
     @Override
-    protected void marshallElementContent(XMLObject samlObject, Element domElement) throws MarshallingException {
+    protected void marshallElementContent(XMLObject samlObject, Element domElement) {
         CountrySamlResponse countrySamlResponse = (CountrySamlResponse) samlObject;
-        ElementSupport.appendTextContent(domElement, countrySamlResponse.getCountrySamlResponse());
+        ElementSupport.appendTextContent(domElement, countrySamlResponse.getValue());
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/CountrySamlResponseUnmarshaller.java
@@ -10,6 +10,6 @@ public class CountrySamlResponseUnmarshaller extends AbstractSAMLObjectUnmarshal
     @Override
     protected void processElementContent(XMLObject samlObject, String elementContent) {
         CountrySamlResponse countrySamlResponse = (CountrySamlResponse) samlObject;
-        countrySamlResponse.setCountrySamlResponse(elementContent);
+        countrySamlResponse.setValue(elementContent);
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysImpl.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysImpl.java
@@ -14,11 +14,19 @@ public class EncryptedAssertionKeysImpl extends AbstractSAMLObject implements En
         super(namespaceURI, elementLocalName, namespacePrefix);
     }
 
-    public String getEncryptedAssertionKeys() { return encryptedAssertionKeys; }
+    @Override
+    public String getValue() {
+        return encryptedAssertionKeys;
+    }
 
-    public void setEncryptedAssertionKeys(String s) { encryptedAssertionKeys = prepareForAssignment(encryptedAssertionKeys, s); }
+    @Override
+    public void setValue(String value) {
+        encryptedAssertionKeys = prepareForAssignment(encryptedAssertionKeys, value);
+    }
 
     @Nullable
     @Override
-    public List<XMLObject> getOrderedChildren() { return null; }
+    public List<XMLObject> getOrderedChildren() {
+        return null;
+    }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysMarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysMarshaller.java
@@ -10,6 +10,6 @@ public class EncryptedAssertionKeysMarshaller extends AbstractSAMLObjectMarshall
     @Override
     protected void marshallElementContent(XMLObject samlObject, Element domElement) {
         EncryptedAssertionKeys encryptedAssertionKeys = (EncryptedAssertionKeys) samlObject;
-        ElementSupport.appendTextContent(domElement, encryptedAssertionKeys.getEncryptedAssertionKeys());
+        ElementSupport.appendTextContent(domElement, encryptedAssertionKeys.getValue());
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/extensions/eidas/impl/EncryptedAssertionKeysUnmarshaller.java
@@ -8,6 +8,6 @@ public class EncryptedAssertionKeysUnmarshaller extends AbstractSAMLObjectUnmars
     @Override
     protected void processElementContent(XMLObject samlObject, String elementContent) {
         EncryptedAssertionKeys encryptedAssertionKeys = (EncryptedAssertionKeys) samlObject;
-        encryptedAssertionKeys.setEncryptedAssertionKeys(elementContent);
+        encryptedAssertionKeys.setValue(elementContent);
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -74,7 +74,7 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
 
     }
 
-    private Optional<String> getUnsignedAssertionValue(List<Attribute> attributes, final String key) {
+    private Optional<String> getUnsignedAssertionAttributeValue(List<Attribute> attributes, final String key) {
         Optional<XMLObject> value = attributes.stream()
                 .filter(attribute -> key.equals(attribute.getName()))
                 .flatMap(attribute -> attribute.getAttributeValues().stream())

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
-import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.core.extensions.eidas.UnsignedAssertionAttributeValue;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
@@ -48,8 +48,8 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
         try {
 
             List<Attribute> attributes = attributeStatements.get(0).getAttributes();
-            Optional<String> encryptedTransientSecretKey = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
-            Optional<String> eidasSaml = getAttributeStringValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+            Optional<String> encryptedTransientSecretKey = getUnsignedAssertionValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+            Optional<String> eidasSaml = getUnsignedAssertionValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
             if (!encryptedTransientSecretKey.isPresent() || !eidasSaml.isPresent()) {
                 return null;
             }
@@ -74,15 +74,16 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
 
     }
 
-    private Optional<String> getAttributeStringValue(List<Attribute> attributes, final String key) {
+    private Optional<String> getUnsignedAssertionValue(List<Attribute> attributes, final String key) {
         Optional<XMLObject> value = attributes.stream()
                 .filter(attribute -> key.equals(attribute.getName()))
                 .flatMap(attribute -> attribute.getAttributeValues().stream())
+                .filter(xmlObject -> xmlObject instanceof UnsignedAssertionAttributeValue)
                 .findFirst();
         String result = null;
         if (value.isPresent()) {
             XMLObject xmlObject = value.get();
-            result = ((StringValueSamlObject) xmlObject).getValue();
+            result = ((UnsignedAssertionAttributeValue) xmlObject).getValue();
         } else {
             LOG.warn("Could not find unsigned assertion attribute with key " + key);
         }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshaller.java
@@ -48,8 +48,8 @@ public class EidasUnsignedMatchingDatasetUnmarshaller extends EidasMatchingDatas
         try {
 
             List<Attribute> attributes = attributeStatements.get(0).getAttributes();
-            Optional<String> encryptedTransientSecretKey = getUnsignedAssertionValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
-            Optional<String> eidasSaml = getUnsignedAssertionValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
+            Optional<String> encryptedTransientSecretKey = getUnsignedAssertionAttributeValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
+            Optional<String> eidasSaml = getUnsignedAssertionAttributeValue(attributes, IdaConstants.Eidas_Attributes.UnsignedAssertions.EidasSamlResponse.NAME);
             if (!encryptedTransientSecretKey.isPresent() || !eidasSaml.isPresent()) {
                 return null;
             }

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
@@ -15,8 +15,9 @@ import org.opensaml.xmlsec.encryption.EncryptedData;
 import org.opensaml.xmlsec.encryption.support.Decrypter;
 import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.domain.MatchingDataset;
-import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.core.extensions.eidas.CountrySamlResponse;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
+import uk.gov.ida.saml.core.extensions.eidas.EncryptedAssertionKeys;
 import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.SecretKeyDecryptorFactory;
@@ -65,10 +66,10 @@ public class EidasUnsignedMatchingDatasetUnmarshallerTest {
     private Attribute attributeEidasResponse;
 
     @Mock
-    private StringValueSamlObject attributeValueEncryptionKeys;
+    private EncryptedAssertionKeys attributeValueEncryptionKeys;
 
     @Mock
-    private StringValueSamlObject attributeValueEidasResponse;
+    private CountrySamlResponse attributeValueEidasResponse;
 
     @Mock
     private PersonIdentifier personIdentifierValue;
@@ -156,6 +157,9 @@ public class EidasUnsignedMatchingDatasetUnmarshallerTest {
         assertThat(matchingDataset).isNotNull();
         verify(firstNameValue).getFirstName();
         verify(personIdentifierValue).getPersonIdentifier();
+        verify(stringtoOpenSamlObjectTransformer).apply("an eidas response string");
+        verify(attributeValueEncryptionKeys).getValue();
+        verify(attributeValueEidasResponse).getValue();
     }
 
 }


### PR DESCRIPTION
Introduce interface `UnsignedAssertionAttributeValue` which is extended by interfaces `CountrySamlResponse` and `EncryptedAssertionKeys`. This interface has
common methods for setting and getting the attribute’s value which means
less class-casting.

I've indicated where this code change is necessary in the comments below.