### PR TITLE
Add a ResponseSizeValidator to be used by Hub and MSA

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/ResponseSizeValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/deserializers/validators/ResponseSizeValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.saml.deserializers.validators;
+
+import com.google.inject.Inject;
+import uk.gov.ida.saml.hub.validators.StringSizeValidator;
+
+import java.util.Objects;
+
+public class ResponseSizeValidator implements SizeValidator {
+    // Ensures someone doing nasty things cannot get loads of data out of core hub in a single response
+
+    protected static final int LOWER_BOUND = 1400;
+    protected static final int UPPER_BOUND = 50000;
+
+    private final StringSizeValidator validator;
+
+    @Inject
+    public ResponseSizeValidator() {
+        this.validator = new StringSizeValidator();
+    }
+
+    @Override
+    public void validate(String input) {
+        validator.validate(Objects.requireNonNull(input, "input for response size validation cannot be null"), getLowerBound(), getUpperBound());
+    }
+
+    private int getUpperBound() {
+        return UPPER_BOUND;
+    }
+
+    protected int getLowerBound() {
+        return LOWER_BOUND;
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/deserializers/validators/ResponseSizeValidatorTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/deserializers/validators/ResponseSizeValidatorTest.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.saml.deserializers.validators;
+
+import org.junit.Test;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+
+import java.util.Arrays;
+
+import static uk.gov.ida.saml.deserializers.validators.ResponseSizeValidator.LOWER_BOUND;
+import static uk.gov.ida.saml.deserializers.validators.ResponseSizeValidator.UPPER_BOUND;
+
+public class ResponseSizeValidatorTest {
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionWhenInputNull() {
+        new ResponseSizeValidator().validate(null);
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void shouldThrowSamlTransformationErrorExceptionWhenInputTooSmall() {
+        new ResponseSizeValidator().validate(createString(LOWER_BOUND - 1));
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void shouldThrowSamlTransformationErrorExceptionWhenInputTooLarge() {
+        new ResponseSizeValidator().validate(createString(UPPER_BOUND + 1));
+    }
+
+    @Test
+    public void shouldThrowNoExceptionWhenResponseSizeOnBoundry() {
+        new ResponseSizeValidator().validate(createString(LOWER_BOUND));
+        new ResponseSizeValidator().validate(createString(UPPER_BOUND));
+    }
+
+    private String createString(int length) {
+        char[] charArray = new char[length];
+        Arrays.fill(charArray, 'a');
+        return new String(charArray);
+    }
+
+
+}


### PR DESCRIPTION
Create a close copy of the `ResponseSizeValidator` class in Hub.

It can then be used by both Hub and the MSA.