### PR TITLE
Validate signature of eidas saml response using country metadata

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/EidasValidatorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/EidasValidatorFactory.java
@@ -6,7 +6,7 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.slf4j.event.Level;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
-import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
+import uk.gov.ida.saml.metadata.MetadataResolverRepository;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
 
@@ -16,10 +16,10 @@ import static java.text.MessageFormat.format;
 
 public class EidasValidatorFactory {
 
-    private EidasMetadataResolverRepository eidasMetadataResolverRepository;
+    private MetadataResolverRepository eidasMetadataResolverRepository;
 
     @Inject
-    public EidasValidatorFactory(EidasMetadataResolverRepository eidasMetadataResolverRepository) {
+    public EidasValidatorFactory(MetadataResolverRepository eidasMetadataResolverRepository) {
         this.eidasMetadataResolverRepository = eidasMetadataResolverRepository;
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/transformers/EidasUnsignedMatchingDatasetUnmarshallerTest.java
@@ -174,11 +174,9 @@ public class EidasUnsignedMatchingDatasetUnmarshallerTest {
     }
 
     @Test
-    public void shouldNotProvideAMatchingDataSetWhenResponseSignatureValidationThrowsException() throws Exception {
+    public void shouldNotProvideAMatchingDataSetWhenResponseSignatureValidationThrowsException() {
         when(unsignedAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(unsignedAttributeStatement));
-        when(eidasAssertion.getAttributeStatements()).thenReturn(ImmutableList.of(eidasAttributeStatement));
         when(unsignedAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(attributeEncryptionKeys, attributeEidasResponse));
-        when(eidasAttributeStatement.getAttributes()).thenReturn(ImmutableList.of(firstName, pid));
         when(attributeEncryptionKeys.getName()).thenReturn(IdaConstants.Eidas_Attributes.UnsignedAssertions.EncryptedSecretKeys.NAME);
         when(attributeEncryptionKeys.getAttributeValues()).thenReturn(ImmutableList.of(attributeValueEncryptionKeys));
         when(attributeEidasResponse.getAttributeValues()).thenReturn(ImmutableList.of(attributeValueEidasResponse));
@@ -186,7 +184,6 @@ public class EidasUnsignedMatchingDatasetUnmarshallerTest {
         when(attributeValueEncryptionKeys.getValue()).thenReturn("an encrypted  key string");
         when(attributeValueEidasResponse.getValue()).thenReturn("an eidas response string");
         when(stringtoOpenSamlObjectTransformer.apply("an eidas response string")).thenReturn(response);
-        when(secretKeyDecryptorFactory.createDecrypter("an encrypted  key string")).thenReturn(decrypter);
         when(eidasValidatorFactory.getValidatedResponse(response)).thenThrow(new SamlTransformationErrorException("an error message", Level.ERROR));
         MatchingDataset matchingDataset = unmarshaller.fromAssertion(unsignedAssertion);
         assertThat(matchingDataset).isNull();


### PR DESCRIPTION
Use an `EidasValidatorFactory` in the `EidasUnsignedMatchingDatasetUnmarshaller` to validate the signature of the eidas saml response.

The signing certificate of the issuing country is used for signature validation, and is resolved from the supplied `MetadataResolverRepository`.

If the signature is invalid, an error will be logged and the MatchingDataset will be null. 