### PR TITLE
BAU bump dropwizard version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ subprojects {
 
     ext {
         opensaml_version = "3.4.3"
-        dropwizard_version = "1.3.13"
-        ida_utils_version = '370'
+        dropwizard_version = "1.3.16"
+        ida_utils_version = '371'
         build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
     }
     group = "uk.gov.ida"


### PR DESCRIPTION
verify-proxy-node baarfs in Travis because of snyk, the latest version of saml-libs will probably fix it but while I was checking I noticed that saml-libs could use the latest version of dropwizard and a newer version of verify-utils-libs.