### PR TITLE
EID-1755 warn (not error) when processing expired assertions

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/BearerSubjectConfirmationValidationSpecification.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/BearerSubjectConfirmationValidationSpecification.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.core.validation.errors;
 
+import org.slf4j.event.Level;
 import uk.gov.ida.saml.core.validation.SamlDocumentReference;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 
@@ -21,6 +22,10 @@ public class BearerSubjectConfirmationValidationSpecification extends SamlValida
 
     public BearerSubjectConfirmationValidationSpecification(String message, Object... parameters) {
         super(format(message, parameters), true);
+    }
+
+    public BearerSubjectConfirmationValidationSpecification(Level logLevel, String message, Object... parameters) {
+        super(format(message, parameters), true, logLevel);
     }
 
     @Override

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactory.java
@@ -271,7 +271,7 @@ public final class SamlTransformationErrorFactory {
     }
 
     public static SamlValidationSpecificationFailure exceededNotOnOrAfter(DateTime expiredTime) {
-        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.EXCEEDED_NOT_ON_OR_AFTER, expiredTime);
+        return new BearerSubjectConfirmationValidationSpecification(Level.WARN, BearerSubjectConfirmationValidationSpecification.EXCEEDED_NOT_ON_OR_AFTER, expiredTime);
     }
 
     public static SamlValidationSpecificationFailure notBeforeExists() {

--- a/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/core/validation/errors/SamlTransformationErrorFactoryTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.core.validation.errors;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.slf4j.event.Level;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
@@ -8,19 +9,25 @@ import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SamlTransformationErrorFactoryTest {
+
     @Test
     public void shouldHaveLevelWarnForDuplicateMatchingDataset() {
         SamlValidationSpecificationFailure failure =
                 SamlTransformationErrorFactory.duplicateMatchingDataset("id", "responseIssuerId");
         assertThat(failure.getLogLevel()).isEqualTo(Level.WARN);
-
     }
+
+    @Test
+    public void shouldHaveLevelWarnForExceededNotOnOrAfter() {
+        SamlValidationSpecificationFailure failure =
+                SamlTransformationErrorFactory.exceededNotOnOrAfter(DateTime.now());
+        assertThat(failure.getLogLevel()).isEqualTo(Level.WARN);
+    }
+
     @Test // arbitrary choice of error
     public void shouldHaveLevelErrorForMissingIssueInstant() {
         SamlValidationSpecificationFailure failure =
                 SamlTransformationErrorFactory.missingIssueInstant("id");
         assertThat(failure.getLogLevel()).isEqualTo(Level.ERROR);
-
     }
-
 }


### PR DESCRIPTION
It's expected that we will sometimes receive expired assertions from IDPs, usually because the user spent too long - probably their session expired too.

https://govukverify.atlassian.net/browse/EID-1755