### PR TITLE
EID-1762 Consolidate eIDAS hash logging

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
@@ -1,0 +1,108 @@
+package uk.gov.ida.eidas.logging;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.transformers.VerifyMatchingDatasetUnmarshaller;
+import uk.gov.ida.saml.hub.factories.UserIdHashFactory;
+import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttributesMapper;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class EidasAttributesLogger {
+    private final Supplier<EidasResponseAttributesHashLogger> loggerSupplier;
+    private final UserIdHashFactory userIdHashFactory;
+
+    public EidasAttributesLogger(
+            Supplier<EidasResponseAttributesHashLogger> loggerSupplier,
+            UserIdHashFactory userIdHashFactory
+    ) {
+        this.loggerSupplier = loggerSupplier;
+        this.userIdHashFactory = userIdHashFactory;
+    }
+
+    public void logEidasAttributesAsHash(
+            HubResponseTranslatorRequestInterface hubResponseTranslatorRequest,
+            TranslatedHubResponseInterface translatedHubResponse
+    ) {
+        EidasResponseAttributesHashLogger hashLogger = loggerSupplier.get();
+        NonMatchingAttributes attributes = translatedHubResponse.getAttributes();
+
+        hashLogger.setPid(translatedHubResponse.getPid());
+
+        updateLoggerAndLog(
+                hashLogger,
+                attributes,
+                hubResponseTranslatorRequest.getRequestId(),
+                hubResponseTranslatorRequest.getDestinationUrl().toString()
+        );
+    }
+
+    public void logEidasAttributesAsHash(Assertion assertion, Response response) {
+        EidasResponseAttributesHashLogger hashLogger = loggerSupplier.get();
+        NonMatchingAttributes attributes = extractAttributes(assertion);
+
+        hashLogger.setPid(
+                getHashedPid(assertion, userIdHashFactory)
+        );
+
+        updateLoggerAndLog(
+                hashLogger,
+                attributes,
+                response.getInResponseTo(),
+                response.getDestination()
+        );
+    }
+
+    private void updateLoggerAndLog(
+            EidasResponseAttributesHashLogger hashLogger,
+            NonMatchingAttributes attributes,
+            String requestId,
+            String destination
+    ) {
+        if (attributes != null) {
+            attributes.getFirstNames().stream()
+                    .filter(NonMatchingVerifiableAttribute::isVerified)
+                    .findFirst()
+                    .ifPresent(firstName -> hashLogger.setFirstName(firstName.getValue()));
+
+            attributes.getMiddleNames().forEach(
+                    middleName -> hashLogger.addMiddleName(middleName.getValue())
+            );
+
+            attributes.getSurnames().forEach(
+                    surname -> hashLogger.addSurname(surname.getValue())
+            );
+
+            attributes.getDatesOfBirth().stream()
+                    .filter(NonMatchingVerifiableAttribute::isVerified)
+                    .findFirst()
+                    .ifPresent(dateOfBirth -> hashLogger.setDateOfBirth(dateOfBirth.getValue()));
+        }
+
+        hashLogger.logHashFor(
+                requestId,
+                destination
+        );
+    }
+
+    private NonMatchingAttributes extractAttributes(Assertion assertion) {
+        VerifyMatchingDatasetUnmarshaller verifyMatchingDatasetUnmarshaller = new VerifyMatchingDatasetUnmarshaller(new AddressFactory());
+        MatchingDataset matchingDataset = verifyMatchingDatasetUnmarshaller.fromAssertion(assertion);
+        MatchingDatasetToNonMatchingAttributesMapper mapper = new MatchingDatasetToNonMatchingAttributesMapper();
+
+        return mapper.mapToNonMatchingAttributes(matchingDataset);
+    }
+
+    private String getHashedPid(Assertion assertion, UserIdHashFactory userIdHashFactory) {
+        return userIdHashFactory.hashId(
+                assertion.getIssuer().getValue(),
+                assertion.getSubject().getNameID().getValue(),
+                Optional.of(AuthnContext.LEVEL_2));
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLogger.java
@@ -1,4 +1,4 @@
-package uk.gov.ida.saml.core.transformers;
+package uk.gov.ida.eidas.logging;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -7,11 +7,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.Lists;
 import org.apache.commons.codec.binary.Hex;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.opensaml.security.crypto.JCAConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,9 +19,10 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
 import java.util.List;
 
-public final class EidasResponseAttributesHashLogger {
+public class EidasResponseAttributesHashLogger {
 
     public static final String MDC_KEY_EIDAS_REQUEST_ID = "hubRequestId";
     public static final String MDC_KEY_EIDAS_DESTINATION = "destination";
@@ -36,8 +35,8 @@ public final class EidasResponseAttributesHashLogger {
     private EidasResponseAttributesHashLogger() {
         responseAttributes = new ResponseAttributes();
         objectMapper = new ObjectMapper();
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        objectMapper.registerModule(new JodaModule());
+        objectMapper.registerModule(new JavaTimeModule());
+
     }
 
     public static EidasResponseAttributesHashLogger instance() {
@@ -60,8 +59,8 @@ public final class EidasResponseAttributesHashLogger {
         this.responseAttributes.addSurname(surname);
     }
 
-    public void setDateOfBirth(DateTime dateOfBirth) {
-        this.responseAttributes.setDateOfBirth(dateOfBirth.toLocalDate());
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.responseAttributes.setDateOfBirth(dateOfBirth);
     }
 
     public void logHashFor(String requestId, String destination) {

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HubResponseTranslatorRequestInterface.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HubResponseTranslatorRequestInterface.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.eidas.logging;
+
+import java.net.URI;
+
+public interface HubResponseTranslatorRequestInterface {
+    String getRequestId();
+    URI getDestinationUrl();
+}

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/TranslatedHubResponseInterface.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/TranslatedHubResponseInterface.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.eidas.logging;
+
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+
+public interface TranslatedHubResponseInterface {
+    String getPid();
+    NonMatchingAttributes getAttributes();
+}

--- a/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/MatchingDatasetBuilder.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/core/transformers/MatchingDatasetBuilder.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
 
-class MatchingDatasetBuilder {
+public class MatchingDatasetBuilder {
     private List<TransliterableMdsValue> firstnames = new ArrayList<>();
     private List<SimpleMdsValue<String>> middlenames = new ArrayList<>();
     private List<TransliterableMdsValue> surnames = new ArrayList<>();

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAddress.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class NonMatchingAddress {
+    private final List<String> lines;
+    private final String postCode;
+    private final String internationalPostCode;
+    private final String uprn;
+
+    @JsonCreator
+    public NonMatchingAddress(
+            @JsonProperty("lines") List<String> lines,
+            @JsonProperty("postCode") @JsonInclude(JsonInclude.Include.NON_NULL) String postCode,
+            @JsonProperty("internationalPostCode") @JsonInclude(JsonInclude.Include.NON_NULL) String internationalPostCode,
+            @JsonProperty("uprn") @JsonInclude(JsonInclude.Include.NON_NULL) String uprn
+    ) {
+        this.lines = lines;
+        this.postCode = postCode;
+        this.internationalPostCode = internationalPostCode;
+        this.uprn = uprn;
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+    public String getPostCode() {
+        return postCode;
+    }
+
+    public String getInternationalPostCode() {
+        return internationalPostCode;
+    }
+
+    public String getUprn() {
+        return uprn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        NonMatchingAddress other = (NonMatchingAddress) o;
+
+        if (lines != null ? !lines.equals(other.lines) : other.lines != null) return false;
+        if (postCode != null ? !postCode.equals(other.postCode) : other.postCode != null) return false;
+        if (uprn != null ? !uprn.equals(other.uprn) : other.uprn != null) return false;
+        return (internationalPostCode != null ? !internationalPostCode.equals(other.internationalPostCode) : other.internationalPostCode != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lines != null ? lines.hashCode() : 0;
+        result = 31 * result + (postCode != null ? postCode.hashCode() : 0);
+        result = 31 * result + (internationalPostCode != null ? internationalPostCode.hashCode() : 0);
+        result = 31 * result + (uprn != null ? uprn.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Address{" +
+                ", lines=" + lines +
+                ", postCode='" + postCode + '\'' +
+                ", internationalPostCode='" + internationalPostCode + '\'' +
+                ", uprn='" + uprn + '\'' +
+                '}';
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
@@ -1,0 +1,118 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.collections.CollectionUtils;
+
+import uk.gov.ida.saml.core.domain.Gender;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NonMatchingAttributes {
+    @JsonProperty("firstNames")
+    private final List<NonMatchingTransliterableAttribute> firstNames;
+    @JsonProperty("middleNames")
+    private final List<NonMatchingVerifiableAttribute<String>> middleNames;
+    @JsonProperty("surnames")
+    private final List<NonMatchingTransliterableAttribute> surnames;
+    @JsonProperty("datesOfBirth")
+    private final List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth;
+    @JsonProperty("gender")
+    private final NonMatchingVerifiableAttribute<Gender> gender;
+    @JsonProperty("addresses")
+    private final List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses;
+
+
+    @JsonCreator
+    public NonMatchingAttributes(
+            @JsonProperty("firstNames")
+                    List<NonMatchingTransliterableAttribute> firstNames,
+            @JsonProperty("middleNames")
+                    List<NonMatchingVerifiableAttribute<String>> middleNames,
+            @JsonProperty("surnames")
+                    List<NonMatchingTransliterableAttribute> surnames,
+            @JsonProperty("datesOfBirth")
+                    List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth,
+            @JsonProperty("gender")
+                    NonMatchingVerifiableAttribute<Gender> gender,
+            @JsonProperty("addresses")
+                    List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses
+    ) {
+        this.firstNames = firstNames;
+        this.middleNames = middleNames;
+        this.surnames = surnames;
+        this.datesOfBirth = datesOfBirth;
+        this.gender = gender;
+        this.addresses = addresses;
+    }
+
+    public List<NonMatchingTransliterableAttribute> getFirstNames() {
+        return firstNames;
+    }
+
+    public List<NonMatchingVerifiableAttribute<String>> getMiddleNames() {
+        return middleNames;
+    }
+
+    public List<NonMatchingTransliterableAttribute> getSurnames() {
+        return surnames;
+    }
+
+    public List<NonMatchingVerifiableAttribute<LocalDate>> getDatesOfBirth() {
+        return datesOfBirth;
+    }
+
+    public NonMatchingVerifiableAttribute<Gender> getGender() {
+        return gender;
+    }
+
+    public List<NonMatchingVerifiableAttribute<NonMatchingAddress>> getAddresses() {
+        return addresses;
+    }
+
+    public static String combineAttributeValues(List<? extends NonMatchingVerifiableAttribute<String>> attributes) {
+        return attributes.stream()
+                .filter(Objects::nonNull)
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(" "));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        NonMatchingAttributes that = (NonMatchingAttributes) o;
+        if (firstNames != null ? !firstNames.equals(that.firstNames) : that.firstNames != null) return false;
+        if (middleNames != null ? !(that.middleNames != null && CollectionUtils.isEqualCollection(middleNames, that.middleNames)) : that.middleNames != null) return false;
+        if (surnames != null ? !(that.surnames != null && CollectionUtils.isEqualCollection(surnames, that.surnames)) : that.surnames != null) return false;
+        if (datesOfBirth != null ? !datesOfBirth.equals(that.datesOfBirth) : that.datesOfBirth != null) return false;
+        if (gender != null ? !gender.equals(that.gender) : that.gender != null) return false;
+        return (addresses != null ? !(that.addresses != null && CollectionUtils.isEqualCollection(addresses, that.addresses)) : that.addresses != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = firstNames != null ? firstNames.hashCode() : 0;
+        result = 31 * result + (middleNames != null ? middleNames.hashCode() : 0);
+        result = 31 * result + (surnames != null ? surnames.hashCode() : 0);
+        result = 31 * result + (datesOfBirth != null ? datesOfBirth.hashCode() : 0);
+        result = 31 * result + (gender != null ? gender.hashCode() : 0);
+        result = 31 * result + (addresses != null ? addresses.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Attributes{ firstNames=%s, middleNames=%s, surnames=%s, datesOfBirth=%s, gender=%s, addresses=%s}",
+                firstNames, middleNames, surnames, datesOfBirth, gender, addresses);
+    }
+
+}

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingTransliterableAttribute.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingTransliterableAttribute.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NonMatchingTransliterableAttribute extends NonMatchingVerifiableAttribute<String> {
+    @JsonProperty("nonLatinScriptValue") @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private final String nonLatinScriptValue;
+
+    @JsonCreator
+    public NonMatchingTransliterableAttribute(
+            @JsonProperty("value")
+                String value,
+            @JsonProperty("nonLatinScriptValue") @JsonInclude(value = JsonInclude.Include.NON_NULL)
+                String nonLatinScriptValue,
+            @JsonProperty("verified")
+                boolean verified,
+            @JsonProperty("from") @JsonInclude(JsonInclude.Include.NON_NULL)
+                LocalDate from,
+            @JsonProperty("to") @JsonInclude(JsonInclude.Include.NON_NULL)
+                LocalDate to
+    ) {
+        super(value, verified, from, to);
+        this.nonLatinScriptValue = nonLatinScriptValue;
+    }
+
+    public String getNonLatinScriptValue() {
+        return nonLatinScriptValue;
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
@@ -1,0 +1,84 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NonMatchingVerifiableAttribute<T> {
+    @JsonProperty("value")
+    private final T value;
+    @JsonProperty("verified")
+    private final boolean verified;
+    @JsonProperty("from") @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final LocalDate from;
+    @JsonProperty("to") @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final LocalDate to;
+
+    @JsonCreator
+    public NonMatchingVerifiableAttribute(
+            @JsonProperty("value")
+                T value,
+            @JsonProperty("verified")
+                boolean verified,
+            @JsonProperty("from") @JsonInclude(JsonInclude.Include.NON_NULL)
+                LocalDate from,
+            @JsonProperty("to") @JsonInclude(JsonInclude.Include.NON_NULL)
+                LocalDate to) {
+        this.value = value;
+        this.verified = verified;
+        this.from = from;
+        this.to = to;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public boolean isVerified() {
+        return verified;
+    }
+
+    public boolean isValid() {
+        return this.verified && this.isCurrent() && this.value != null;
+    }
+
+    public boolean isCurrent() {
+        return (this.from != null && this.from.isBefore(LocalDate.now())) &&
+                (this.to == null || this.to.isAfter(LocalDate.now()));
+    }
+
+    public LocalDate getFrom() { return from; }
+
+    public LocalDate getTo() { return to; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        NonMatchingVerifiableAttribute<?> that = (NonMatchingVerifiableAttribute<?>) o;
+
+        return isVerified() == that.isVerified() &&
+                getValue().equals(that.getValue()) &&
+                getFrom().equals(that.getFrom()) &&
+                getTo().equals(that.getTo());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getValue().hashCode();
+        result = 31 * result + (isVerified() ? 1 : 0);
+        result = 31 * result + getFrom().hashCode();
+        result = 31 * result + getTo().hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("NonMatchingVerifiableAttribute{ value=%s, verified=%s, from=%s, to=%s }", value, verified, from, to);
+    }
+}

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapper.java
@@ -1,0 +1,148 @@
+package uk.gov.ida.verifyserviceprovider.mappers;
+
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAddress;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingTransliterableAttribute;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MatchingDatasetToNonMatchingAttributesMapper {
+    public NonMatchingAttributes mapToNonMatchingAttributes(MatchingDataset matchingDataset) {
+        List<NonMatchingTransliterableAttribute> firstNames = convertTransliterableNameAttributes(matchingDataset.getFirstNames());
+        List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth = convertDateOfBirths(matchingDataset.getDateOfBirths());
+        List<NonMatchingVerifiableAttribute<String>> middleNames = convertNameAttributes(matchingDataset.getMiddleNames());
+        List<NonMatchingTransliterableAttribute> surnames = convertTransliterableNameAttributes(matchingDataset.getSurnames());
+        NonMatchingVerifiableAttribute<Gender> gender = matchingDataset.getGender()
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .orElse(null);
+        List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses = mapAddresses(matchingDataset.getAddresses());
+
+        return new NonMatchingAttributes(
+                firstNames,
+                middleNames,
+                surnames,
+                datesOfBirth,
+                gender,
+                addresses
+        );
+    }
+
+    private List<NonMatchingVerifiableAttribute<String>> convertNameAttributes(List<SimpleMdsValue<String>> values) {
+        return values.stream()
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .sorted(attributeComparator())
+                .collect(Collectors.toList());
+    }
+
+    private List<NonMatchingVerifiableAttribute<LocalDate>> convertDateOfBirths(List<SimpleMdsValue<org.joda.time.LocalDate>> values) {
+        return values.stream()
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertWrappedJodaLocalDateToJavaLocalDate)
+                .map(this::mapToNonMatchingVerifiableAttribute)
+                .sorted(attributeComparator())
+                .collect(Collectors.toList());
+    }
+
+    private List<NonMatchingTransliterableAttribute> convertTransliterableNameAttributes(List<TransliterableMdsValue> values) {
+        return values.stream()
+                .map(this::mapToTransliterableAttribute)
+                .sorted(attributeComparator())
+                .collect(Collectors.toList());
+    }
+
+
+    private NonMatchingTransliterableAttribute mapToTransliterableAttribute(TransliterableMdsValue transliterableMdsValue) {
+        LocalDate from = Optional.ofNullable(transliterableMdsValue.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        LocalDate to = Optional.ofNullable(transliterableMdsValue.getTo())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        return new NonMatchingTransliterableAttribute(
+                transliterableMdsValue.getValue(),
+                transliterableMdsValue.getNonLatinScriptValue(),
+                transliterableMdsValue.isVerified(),
+                from,
+                to
+        );
+    }
+
+    private <T> NonMatchingVerifiableAttribute<T> mapToNonMatchingVerifiableAttribute(SimpleMdsValue<T> simpleMdsValueOptional) {
+        LocalDate from = Optional.ofNullable(simpleMdsValueOptional.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        LocalDate to = Optional.ofNullable(simpleMdsValueOptional.getTo())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        return new NonMatchingVerifiableAttribute<>(
+                simpleMdsValueOptional.getValue(),
+                simpleMdsValueOptional.isVerified(),
+                from,
+                to
+        );
+    }
+
+    private List<NonMatchingVerifiableAttribute<NonMatchingAddress>> mapAddresses(List<Address> addresses) {
+        return addresses.stream().map(this::mapAddress).sorted(attributeComparator()).collect(Collectors.toList());
+    }
+
+    private NonMatchingVerifiableAttribute<NonMatchingAddress> mapAddress(Address input) {
+        NonMatchingAddress transformedAddress = new NonMatchingAddress(
+                input.getLines(),
+                input.getPostCode().orElse(null),
+                input.getInternationalPostCode().orElse(null),
+                input.getUPRN().orElse(null)
+        );
+
+        LocalDate from = Optional.ofNullable(input.getFrom())
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        LocalDate to = input.getTo()
+                .map(MatchingDatasetToNonMatchingAttributesMapper::convertJodaDateTimeToJavaLocalDate)
+                .orElse(null);
+
+        return new NonMatchingVerifiableAttribute<>(
+                transformedAddress,
+                input.isVerified(),
+                from,
+                to
+        );
+    }
+
+    private static LocalDate convertJodaDateTimeToJavaLocalDate(org.joda.time.DateTime jodaDateTime) {
+        return LocalDate.of(
+                jodaDateTime.getYear(),
+                jodaDateTime.getMonthOfYear(),
+                jodaDateTime.getDayOfMonth()
+        );
+    }
+
+    private static LocalDate convertJodaLocalDateToJavaLocalDate(org.joda.time.LocalDate jodaDate) {
+        return LocalDate.of(jodaDate.getYear(), jodaDate.getMonthOfYear(), jodaDate.getDayOfMonth());
+    }
+
+    private static SimpleMdsValue<LocalDate> convertWrappedJodaLocalDateToJavaLocalDate(SimpleMdsValue<org.joda.time.LocalDate> wrappedJodaDate) {
+        LocalDate javaLocalDate = convertJodaLocalDateToJavaLocalDate(wrappedJodaDate.getValue());
+        return new SimpleMdsValue<>(javaLocalDate, wrappedJodaDate.getFrom(), wrappedJodaDate.getTo(), wrappedJodaDate.isVerified());
+    }
+
+    public static <T> Comparator<NonMatchingVerifiableAttribute<T>> attributeComparator() {
+        return Comparator.<NonMatchingVerifiableAttribute<T>, LocalDate>comparing(NonMatchingVerifiableAttribute::getTo, Comparator.nullsFirst(Comparator.reverseOrder()))
+                .thenComparing(NonMatchingVerifiableAttribute::isVerified, Comparator.reverseOrder())
+                .thenComparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
@@ -1,0 +1,365 @@
+package uk.gov.ida.eidas.logging;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.Date;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.hub.factories.UserIdHashFactory;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingTransliterableAttribute;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EidasAttributesLoggerTest {
+
+    @Mock
+    private EidasResponseAttributesHashLogger hashLogger;
+
+    @Mock
+    private HubResponseTranslatorRequestInterface hubResponseTranslatorRequest;
+
+    @Mock
+    private TranslatedHubResponseInterface translatedHubResponse;
+
+    @Mock
+    private NonMatchingAttributes attributes;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private Attribute attribute;
+
+    @Mock
+    private AttributeStatement attributeStatement;
+
+    @Mock
+    private NameID nameID;
+
+    @Mock
+    private Subject subject;
+
+    @Mock
+    private Issuer issuer;
+
+    @Mock
+    private Assertion assertion;
+
+
+    private String entityId = "entityId";
+    private String hashedPid = "f5f02791bb8eb83e81759b6f1ee744795048c2b45484842e403a42034fddd2c9";
+    private String unHashedPid = "unHashedPid";
+    private String requestId = "requestId";
+    private String issuerId = "issuer";
+    private URI destination = URI.create("http://destination");
+    private EidasAttributesLogger proxyNodeEidasAttributesLogger;
+    private EidasAttributesLogger hubEidasAttributesLogger;
+
+    @Before
+    public void setUp() {
+        when(translatedHubResponse.getAttributes()).thenReturn(attributes);
+        when(translatedHubResponse.getPid()).thenReturn(hashedPid);
+
+        when(hubResponseTranslatorRequest.getRequestId()).thenReturn(requestId);
+        when(hubResponseTranslatorRequest.getDestinationUrl()).thenReturn(destination);
+
+        when(response.getInResponseTo()).thenReturn(requestId);
+        when(response.getDestination()).thenReturn(destination.toString());
+
+        when(attributeStatement.getAttributes()).thenReturn(Arrays.asList(attribute));
+
+        when(nameID.getValue()).thenReturn(unHashedPid);
+
+        when(subject.getNameID()).thenReturn(nameID);
+
+        when(issuer.getValue()).thenReturn(issuerId);
+
+        when(assertion.getAttributeStatements()).thenReturn(Arrays.asList(attributeStatement));
+        when(assertion.getSubject()).thenReturn(subject);
+        when(assertion.getIssuer()).thenReturn(issuer);
+
+        proxyNodeEidasAttributesLogger = new EidasAttributesLogger(
+                () -> hashLogger,
+                null
+        );
+        hubEidasAttributesLogger = new EidasAttributesLogger(
+                () -> hashLogger,
+                new UserIdHashFactory(entityId)
+        );
+    }
+    
+    @Test
+    public void fromProxyNodeOnlyFirstVerifiedFirstNameIsHashed() {
+        List<NonMatchingTransliterableAttribute> firstNames = new ArrayList<>();
+
+        firstNames.add(new NonMatchingTransliterableAttribute("John", "John", false, LocalDate.now(), LocalDate.now()));
+        firstNames.add(new NonMatchingTransliterableAttribute("Paul", "Paul", true, LocalDate.now(), LocalDate.now()));
+        firstNames.add(new NonMatchingTransliterableAttribute("George", "George", false, LocalDate.now(), LocalDate.now()));
+
+        when(attributes.getFirstNames()).thenReturn(firstNames);
+
+        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger).setFirstName("Paul");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromHubOnlyFirstVerifiedFirstNameIsHashed() {
+        PersonName attributeValue0 = mock(PersonName.class);
+        when(attributeValue0.getVerified()).thenReturn(false);
+        when(attributeValue0.getValue()).thenReturn("John");
+
+        PersonName attributeValue1 = mock(PersonName.class);
+        when(attributeValue1.getVerified()).thenReturn(true);
+        when(attributeValue1.getValue()).thenReturn("Paul");
+
+        PersonName attributeValue2 = mock(PersonName.class);
+        when(attributeValue2.getVerified()).thenReturn(true);
+        when(attributeValue2.getValue()).thenReturn("George");
+
+        setUpAttributeMock(
+                Arrays.asList(attributeValue0, attributeValue1, attributeValue2),
+                IdaConstants.Attributes_1_1.Firstname.NAME
+        );
+
+        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger).setFirstName("Paul");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromProxyNodeUnverifiedFirstNamesNeverLogged() {
+        List<NonMatchingTransliterableAttribute> firstNames = new ArrayList<>();
+
+        firstNames.add(new NonMatchingTransliterableAttribute("John", "John", false, LocalDate.now(), LocalDate.now()));
+        firstNames.add(new NonMatchingTransliterableAttribute("Paul", "Paul", false, LocalDate.now(), LocalDate.now()));
+        firstNames.add(new NonMatchingTransliterableAttribute("George", "George", false, LocalDate.now(), LocalDate.now()));
+
+        when(attributes.getFirstNames()).thenReturn(firstNames);
+
+        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger, never()).setFirstName(any());
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromHubNodeUnverifiedFirstNamesNeverLogged() {
+        PersonName attributeValue0 = mock(PersonName.class);
+        when(attributeValue0.getVerified()).thenReturn(false);
+        when(attributeValue0.getValue()).thenReturn("John");
+
+        PersonName attributeValue1 = mock(PersonName.class);
+        when(attributeValue1.getVerified()).thenReturn(false);
+        when(attributeValue1.getValue()).thenReturn("Paul");
+
+        PersonName attributeValue2 = mock(PersonName.class);
+        when(attributeValue2.getVerified()).thenReturn(false);
+        when(attributeValue2.getValue()).thenReturn("George");
+
+        setUpAttributeMock(
+                Arrays.asList(attributeValue0, attributeValue1, attributeValue2),
+                IdaConstants.Attributes_1_1.Firstname.NAME
+        );
+
+        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger, never()).setFirstName(any());
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromProxyNodeOnlyFirstVerifiedDateOfBirthIsHashed() {
+        List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth = new ArrayList<>();
+
+        datesOfBirth.add(new NonMatchingVerifiableAttribute<>(LocalDate.of(1940, 10, 9), false, LocalDate.now(), LocalDate.now()));
+        datesOfBirth.add(new NonMatchingVerifiableAttribute<>(LocalDate.of(1942, 6, 18), false, LocalDate.now(), LocalDate.now()));
+        datesOfBirth.add(new NonMatchingVerifiableAttribute<>(LocalDate.of(1943, 2, 25),true, LocalDate.now(), LocalDate.now()));
+
+        when(attributes.getDatesOfBirth()).thenReturn(datesOfBirth);
+
+        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger).setDateOfBirth(LocalDate.of(1943, 2, 25));
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromHubNodeOnlyFirstVerifiedDateOfBirthIsHashed() {
+        Date attributeValue0 = mock(Date.class);
+        when(attributeValue0.getVerified()).thenReturn(false);
+        when(attributeValue0.getValue()).thenReturn("1940-10-09");
+
+        Date attributeValue1 = mock(Date.class);
+        when(attributeValue1.getVerified()).thenReturn(false);
+        when(attributeValue1.getValue()).thenReturn("1942-06-18");
+
+        Date attributeValue2 = mock(Date.class);
+        when(attributeValue2.getVerified()).thenReturn(true);
+        when(attributeValue2.getValue()).thenReturn("1943-02-25");
+
+        setUpAttributeMock(
+                Arrays.asList(attributeValue0, attributeValue1, attributeValue2),
+                IdaConstants.Attributes_1_1.DateOfBirth.NAME
+        );
+
+        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+
+        verify(hashLogger).setPid(hashedPid);
+        verify(hashLogger).setDateOfBirth(LocalDate.of(1943, 2, 25));
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromProxyNodeAllMiddleNamesHashedInCorrectOrder() {
+        List<NonMatchingVerifiableAttribute<String>> middleNames = new ArrayList<>();
+
+        middleNames.add(new NonMatchingVerifiableAttribute<>("Winston", false, LocalDate.now(), LocalDate.now()));
+        middleNames.add(new NonMatchingVerifiableAttribute<>("James", false, LocalDate.now(), LocalDate.now()));
+        middleNames.add(new NonMatchingVerifiableAttribute<>("Carl",true, LocalDate.now(), LocalDate.now()));
+
+        when(attributes.getMiddleNames()).thenReturn(middleNames);
+
+        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+
+        InOrder inOrder = inOrder(hashLogger);
+        verify(hashLogger).setPid(hashedPid);
+        inOrder.verify(hashLogger).addMiddleName("Winston");
+        inOrder.verify(hashLogger).addMiddleName("James");
+        inOrder.verify(hashLogger).addMiddleName("Carl");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromHubAllMiddleNamesHashedInCorrectOrder() {
+        PersonName attributeValue0 = mock(PersonName.class);
+        when(attributeValue0.getVerified()).thenReturn(false);
+        when(attributeValue0.getValue()).thenReturn("Winston");
+        when(attributeValue0.getTo()).thenReturn(DateTime.now().minusDays(2));
+
+        PersonName attributeValue1 = mock(PersonName.class);
+        when(attributeValue1.getVerified()).thenReturn(false);
+        when(attributeValue1.getValue()).thenReturn("James");
+        when(attributeValue1.getTo()).thenReturn(DateTime.now().minusDays(1));
+
+        PersonName attributeValue2 = mock(PersonName.class);
+        when(attributeValue2.getVerified()).thenReturn(true);
+        when(attributeValue2.getValue()).thenReturn("Carl");
+        when(attributeValue2.getTo()).thenReturn(DateTime.now());
+
+        setUpAttributeMock(
+                Arrays.asList(attributeValue0, attributeValue1, attributeValue2),
+                IdaConstants.Attributes_1_1.Middlename.NAME
+        );
+
+        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+
+        InOrder inOrder = inOrder(hashLogger);
+        verify(hashLogger).setPid(hashedPid);
+        inOrder.verify(hashLogger).addMiddleName("Carl");
+        inOrder.verify(hashLogger).addMiddleName("James");
+        inOrder.verify(hashLogger).addMiddleName("Winston");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromProxyNodeAllSurnamesHashedInCorrectOrder() {
+        List<NonMatchingTransliterableAttribute> surnames = new ArrayList<>();
+
+        surnames.add(new NonMatchingTransliterableAttribute("Lennon", "Lennon", true, LocalDate.now(), LocalDate.now()));
+        surnames.add(new NonMatchingTransliterableAttribute("McCartney", "McCartney",false, LocalDate.now(), LocalDate.now()));
+        surnames.add(new NonMatchingTransliterableAttribute("Harrison", "Harrison", true, LocalDate.now(), LocalDate.now()));
+
+        when(attributes.getSurnames()).thenReturn(surnames);
+
+        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+
+        InOrder inOrder = inOrder(hashLogger);
+        verify(hashLogger).setPid(hashedPid);
+        inOrder.verify(hashLogger).addSurname("Lennon");
+        inOrder.verify(hashLogger).addSurname("McCartney");
+        inOrder.verify(hashLogger).addSurname("Harrison");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    @Test
+    public void fromHubAllSurnamesHashedInCorrectOrder() {
+        PersonName attributeValue0 = mock(PersonName.class);
+        when(attributeValue0.getVerified()).thenReturn(false);
+        when(attributeValue0.getValue()).thenReturn("Lennon");
+        when(attributeValue0.getTo()).thenReturn(DateTime.now().minusDays(2));
+
+        PersonName attributeValue1 = mock(PersonName.class);
+        when(attributeValue1.getVerified()).thenReturn(false);
+        when(attributeValue1.getValue()).thenReturn("McCartney");
+        when(attributeValue1.getTo()).thenReturn(DateTime.now());
+
+        PersonName attributeValue2 = mock(PersonName.class);
+        when(attributeValue2.getVerified()).thenReturn(true);
+        when(attributeValue2.getValue()).thenReturn("Harrison");
+        when(attributeValue2.getTo()).thenReturn(DateTime.now().minusDays(1));
+
+        setUpAttributeMock(
+                Arrays.asList(attributeValue0, attributeValue1, attributeValue2),
+                IdaConstants.Attributes_1_1.Surname.NAME
+        );
+
+        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+
+        InOrder inOrder = inOrder(hashLogger);
+        verify(hashLogger).setPid(hashedPid);
+        inOrder.verify(hashLogger).addSurname("McCartney");
+        inOrder.verify(hashLogger).addSurname("Harrison");
+        inOrder.verify(hashLogger).addSurname("Lennon");
+        verify(hashLogger).logHashFor(requestId, destination.toString());
+        verifyNoMoreInteractions(hashLogger);
+    }
+
+    private void setUpAttributeMock(List attributes, String attributeNameConstant) {
+        when(attribute.getName()).thenReturn(attributeNameConstant);
+        when(attribute.getAttributeValues()).thenReturn(attributes);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLoggerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLoggerTest.java
@@ -1,11 +1,10 @@
-package uk.gov.ida.saml.core.transformers;
+package uk.gov.ida.eidas.logging;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import org.apache.commons.lang.reflect.FieldUtils;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -13,14 +12,15 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_DESTINATION;
-import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_REQUEST_ID;
-import static uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_USER_HASH;
+import static uk.gov.ida.eidas.logging.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_DESTINATION;
+import static uk.gov.ida.eidas.logging.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_REQUEST_ID;
+import static uk.gov.ida.eidas.logging.EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_USER_HASH;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EidasResponseAttributesHashLoggerTest {
@@ -34,7 +34,7 @@ public class EidasResponseAttributesHashLoggerTest {
 
     @Test
     public void testDifferentInputProduceDifferentHashes() {
-        DateTime now = DateTime.now();
+        LocalDate now = LocalDate.now();
 
         EidasResponseAttributesHashLogger logger1 = EidasResponseAttributesHashLogger.instance();
         logger1.setPid("a");
@@ -57,7 +57,7 @@ public class EidasResponseAttributesHashLoggerTest {
 
     @Test
     public void testSamePidsProduceSameHashes() {
-        DateTime now = DateTime.now();
+        LocalDate now = LocalDate.now();
 
         EidasResponseAttributesHashLogger logger1 = EidasResponseAttributesHashLogger.instance();
         logger1.setPid("a");
@@ -93,27 +93,6 @@ public class EidasResponseAttributesHashLoggerTest {
         logger3.addMiddleName("mn2");
         logger3.addMiddleName("mn1");
         assertThat(hash1).isNotEqualTo(buildHash(logger3));
-
-
-    }
-
-    @Test
-    public void testDateOfBirthIsStoredAndHashedAsLocalDate() {
-        DateTime beginningOfToday = new DateTime().withTimeAtStartOfDay();
-        DateTime oneHourLater = beginningOfToday.plusHours(1);
-        DateTime tomorrow = beginningOfToday.plusDays(1).withTimeAtStartOfDay();
-
-        EidasResponseAttributesHashLogger logger = EidasResponseAttributesHashLogger.instance();
-        logger.setDateOfBirth(beginningOfToday);
-        String hash1 = buildHash(logger);
-
-        logger.setDateOfBirth(oneHourLater);
-        String hash2 = buildHash(logger);
-        assertThat(hash1).isEqualTo(hash2);
-
-        logger.setDateOfBirth(tomorrow);
-        String hash3 = buildHash(logger);
-        assertThat(hash2).isNotEqualTo(hash3);
     }
 
     @Test
@@ -153,17 +132,13 @@ public class EidasResponseAttributesHashLoggerTest {
         String expectedStringToHash = "{\"pid\":\"a\",\"firstName\":\"fn\",\"middleNames\":[\"m1\",\"mn2\"],\"surnames\":[\"sn\"],\"dateOfBirth\":\"2019-03-24\"}";
         String expectedHash = getExpectedHash(logger, expectedStringToHash);
 
-        DateTime startOfToday = DateTime.now()
-                .withYear(2019)
-                .withMonthOfYear(3)
-                .withDayOfMonth(24)
-                .withTimeAtStartOfDay();
+        LocalDate dateOfBirth = LocalDate.of(2019, 3, 24);
         logger.setPid("a");
         logger.setFirstName("fn");
         logger.addMiddleName("m1");
         logger.addMiddleName("mn2");
         logger.addSurname("sn");
-        logger.setDateOfBirth(startOfToday);
+        logger.setDateOfBirth(dateOfBirth);
         assertThat(buildHash(logger)).isEqualTo(expectedHash);
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
+++ b/saml-lib/src/test/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttributeBuilder.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.verifyserviceprovider.dto;
+
+import java.time.LocalDate;
+
+public class NonMatchingVerifiableAttributeBuilder {
+    private String value = "VALUE";
+    private boolean verified = true;
+    private LocalDate from = LocalDate.now();
+    private LocalDate to = null;
+
+    public NonMatchingVerifiableAttributeBuilder withVerified(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttributeBuilder withFrom(LocalDate from) {
+        this.from = from;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttributeBuilder withTo(LocalDate to) {
+        this.to = to;
+        return this;
+    }
+
+    public NonMatchingVerifiableAttribute<String> build() {
+        return new NonMatchingVerifiableAttribute<>(value, verified, from, to);
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/verifyserviceprovider/mappers/MatchingDatasetToNonMatchingAttributesMapperTest.java
@@ -1,0 +1,400 @@
+package uk.gov.ida.verifyserviceprovider.mappers;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+import uk.gov.ida.saml.core.domain.TransliterableMdsValue;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAddress;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingTransliterableAttribute;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
+import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttributeBuilder;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MatchingDatasetToNonMatchingAttributesMapperTest {
+
+    private final DateTime fromTwo = DateTime.now().minusDays(30);
+    private final DateTime fromOne = DateTime.now();
+    private final DateTime fromThree = DateTime.now().minusDays(6);
+    private final DateTime fromFour = null;
+
+    private final String foo = "Foo";
+    private final String bar = "Bar";
+    private final String baz = "Baz";
+    private final String fuu = "Fuu";
+
+    @Test
+    public void shouldMapFirstNames() {
+        List<TransliterableMdsValue> firstNames = asList(
+                createTransliterableValue(fromThree, foo),
+                createTransliterableValue(fromTwo, bar),
+                createTransliterableValue(fromOne, baz),
+                createTransliterableValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                firstNames,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getFirstNames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getFirstNames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapFirstNamesWithNonLatinScriptValue() {
+        String nonLatinScript = "nonLatinScript";
+        List<TransliterableMdsValue> firstNames = asList(
+                createTransliterableValue(foo, nonLatinScript)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                firstNames,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingTransliterableAttribute nonMatchingTransliterableAttribute = nonMatchingAttributes.getFirstNames().get(0);
+        assertThat(nonMatchingTransliterableAttribute.getValue()).isEqualTo(foo);
+        assertThat(nonMatchingTransliterableAttribute.getNonLatinScriptValue()).isEqualTo(nonLatinScript);
+    }
+
+    @Test
+    public void shouldMapMiddlenames() {
+        List<SimpleMdsValue<String>> middleNames = asList(
+                createSimpleMdsValue(fromThree, foo),
+                createSimpleMdsValue(fromTwo, bar),
+                createSimpleMdsValue(fromOne, baz),
+                createSimpleMdsValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                middleNames,
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getMiddleNames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getMiddleNames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapSurnames() {
+        List<TransliterableMdsValue> surnames = asList(
+                createTransliterableValue(fromThree, foo),
+                createTransliterableValue(fromTwo, bar),
+                createTransliterableValue(fromOne, baz),
+                createTransliterableValue(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                surnames,
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getSurnames().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getSurnames()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapSurnamesWithNonLatinScriptValue() {
+        String nonLatinScript = "nonLatinScript";
+        List<TransliterableMdsValue> surnames = asList(
+                createTransliterableValue(foo, nonLatinScript)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                surnames,
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingTransliterableAttribute nonMatchingTransliterableAttribute = nonMatchingAttributes.getSurnames().get(0);
+        assertThat(nonMatchingTransliterableAttribute.getValue()).isEqualTo(foo);
+        assertThat(nonMatchingTransliterableAttribute.getNonLatinScriptValue()).isEqualTo(nonLatinScript);
+    }
+
+    @Test
+    public void shouldMapDatesOfBirth() {
+        org.joda.time.LocalDate fooDate = org.joda.time.LocalDate.now();
+        org.joda.time.LocalDate barDate = org.joda.time.LocalDate.now().minusDays(5);
+        org.joda.time.LocalDate bazDate = org.joda.time.LocalDate.now().minusDays(10);
+        org.joda.time.LocalDate fuuDate = org.joda.time.LocalDate.now().minusDays(15);
+        List<SimpleMdsValue<org.joda.time.LocalDate>> datesOfBirth = asList(
+                createDateValue(fromThree, fooDate),
+                createDateValue(fromTwo, barDate),
+                createDateValue(fromOne, bazDate),
+                createDateValue(fromFour, fuuDate)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                datesOfBirth,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        List<String> expectedDates = Stream.of(bazDate, fooDate, barDate, fuuDate)
+                .map(org.joda.time.LocalDate::toString)
+                .collect(Collectors.toList());
+        assertThat(nonMatchingAttributes.getDatesOfBirth().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(LocalDate::toString)
+                .collect(Collectors.toList()))
+                .isEqualTo(expectedDates);
+        assertThat(nonMatchingAttributes.getDatesOfBirth()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapAddressesAndNotDiscardAttributes() {
+        Address addressIn = createAddress(fromOne, baz);
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.singletonList(addressIn),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        NonMatchingAddress addressOut = nonMatchingAttributes.getAddresses().get(0).getValue();
+        assertThat(addressOut.getPostCode()).isEqualTo(addressIn.getPostCode().get());
+        assertThat(addressOut.getInternationalPostCode()).isEqualTo(addressIn.getInternationalPostCode().get());
+        assertThat(addressOut.getUprn()).isEqualTo(addressIn.getUPRN().get());
+        assertThat(addressOut.getLines()).isEqualTo(addressIn.getLines());
+
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapCurrentAddress() {
+        List<Address> currentAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromTwo, bar),
+                createAddress(fromOne, baz),
+                createAddress(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                currentAddress,
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapPreviousAddress() {
+        List<Address> previousAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromTwo, bar),
+                createAddress(fromOne, baz),
+                createAddress(fromFour, fuu)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                previousAddress,
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapAndMergeAddress() {
+        List<Address> previousAddress = asList(
+                createAddress(fromThree, foo),
+                createAddress(fromFour, fuu)
+        );
+        List<Address> currentAddress = asList(
+                createAddress(fromOne, baz),
+                createAddress(fromTwo, bar)
+        );
+
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty(),
+                Collections.emptyList(),
+                currentAddress,
+                previousAddress,
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getAddresses().stream()
+                .map(NonMatchingVerifiableAttribute::getValue)
+                .map(NonMatchingAddress::getPostCode)
+                .collect(Collectors.toList()))
+                .isEqualTo(asList(baz, foo, bar, fuu));
+        assertThat(nonMatchingAttributes.getAddresses()).isSortedAccordingTo(comparedByFromDate());
+    }
+
+    @Test
+    public void shouldMapGender() {
+        Gender gender = Gender.NOT_SPECIFIED;
+        MatchingDataset matchingDataset = new MatchingDataset(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.of(new SimpleMdsValue<>(gender, null, null, true)),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        );
+        NonMatchingAttributes nonMatchingAttributes = new MatchingDatasetToNonMatchingAttributesMapper().mapToNonMatchingAttributes(matchingDataset);
+
+        assertThat(nonMatchingAttributes.getGender().getValue()).isEqualTo(gender);
+    }
+
+    @Test
+    public void sortTheListByToDateThenIsVerifiedThenFromDate() {
+        LocalDate now = LocalDate.now();
+        LocalDate fiveDaysAgo = now.minusDays(5);
+        LocalDate threeDaysAgo = now.minusDays(3);
+        NonMatchingVerifiableAttribute<String> attributeOne = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(null).withFrom(now).build();
+        NonMatchingVerifiableAttribute<String> attributeTwo = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(null).withFrom(fiveDaysAgo).build();
+        NonMatchingVerifiableAttribute<String> attributeThree = new NonMatchingVerifiableAttributeBuilder().withVerified(false).withTo(null).withFrom(now).build();
+        NonMatchingVerifiableAttribute<String> attributeFour = new NonMatchingVerifiableAttributeBuilder().withVerified(false).withTo(now).withFrom(now).build();
+        NonMatchingVerifiableAttribute<String> attributeFive = new NonMatchingVerifiableAttributeBuilder().withVerified(false).withTo(now).withFrom(fiveDaysAgo).build();
+        NonMatchingVerifiableAttribute<String> attributeSix = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(fiveDaysAgo).withFrom(now).build();
+        NonMatchingVerifiableAttribute<String> attributeSeven = new NonMatchingVerifiableAttributeBuilder().withVerified(true).withTo(fiveDaysAgo).withFrom(threeDaysAgo).build();
+        NonMatchingVerifiableAttribute<String> attributeEight = new NonMatchingVerifiableAttributeBuilder().withVerified(false).withTo(fiveDaysAgo).withFrom(null).build();
+        List<NonMatchingVerifiableAttribute<String>> unsorted = asList(
+                attributeFour,
+                attributeOne,
+                attributeSix,
+                attributeTwo,
+                attributeSeven,
+                attributeFive,
+                attributeThree,
+                attributeEight
+        );
+        assertThat(unsorted.stream().sorted(MatchingDatasetToNonMatchingAttributesMapper.attributeComparator()).collect(Collectors.toList())).isEqualTo(
+                asList(
+                        attributeOne,
+                        attributeTwo,
+                        attributeThree,
+                        attributeFour,
+                        attributeFive,
+                        attributeSix,
+                        attributeSeven,
+                        attributeEight
+                )
+        );
+    }
+
+    private Comparator<NonMatchingVerifiableAttribute<?>> comparedByFromDate() {
+        return Comparator.comparing(NonMatchingVerifiableAttribute::getFrom, Comparator.nullsLast(Comparator.reverseOrder()));
+    }
+
+    private Address createAddress(DateTime from, String postCode) {
+        return new Address(Collections.emptyList(), postCode, "BAR", "BAZ", from, null, true);
+    }
+
+    private TransliterableMdsValue createTransliterableValue(DateTime from, String value) {
+        return new TransliterableMdsValue(createSimpleMdsValue(from, value));
+    }
+
+    private TransliterableMdsValue createTransliterableValue(String value, String nonLatinScript) {
+        return new TransliterableMdsValue(value, nonLatinScript);
+    }
+
+    private SimpleMdsValue<String> createSimpleMdsValue(DateTime from, String value) {
+        return new SimpleMdsValue<>(value, from, null, true);
+    }
+
+    private SimpleMdsValue<org.joda.time.LocalDate> createDateValue(DateTime from, org.joda.time.LocalDate dateTime) {
+        return new SimpleMdsValue<>(dateTime, from, null, true);
+    }
+}


### PR DESCRIPTION
We log hashes of eIDAS attributes in the hub and the proxy-node. These
are then compared in Splunk to ensure nothing bad is happening.

The logic to do this was split over three places - the VSP, the
proxy-node and the hub. We want to consolidate the logic to ensure the
hashing is done in the same way.

The VSP extract the values from the attributes using the `MatchingDatasetToNonMatchingAttributesMapper`
which are then serialized and sent to the proxy-node using various
DTOs. This logic and DTOs have been imported to saml-lib. This allows
the hub to use the mapper to extract attributes directly from an
assertion using exactly the same logic as the VSP. The DTOs are now
available to the proxy-node to ensure that the serialized attributes are
de-serialized into the same objects.

There are some interfaces created which are implemented in the
proxy-node to ensure that the `EidasAttributesLogger` can accept certain
objects, without having to move proxy-node logic to saml-lib when it
really doesn't need to.

The `EidasAttributesLogger` class is what should be used in both the
proxy-node and the hub. It unifies the logic for extracting attributes
so that users have a consistent experience in both projects.