### PR TITLE
EID-1762 Refactor out need for interfaces

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
@@ -20,16 +20,14 @@ public class EidasAttributesLogger {
 
     public EidasAttributesLogger(
             Supplier<EidasResponseAttributesHashLogger> loggerSupplier,
-            UserIdHashFactory userIdHashFactory
-    ) {
+            UserIdHashFactory userIdHashFactory) {
         this.loggerSupplier = loggerSupplier;
         this.userIdHashFactory = userIdHashFactory;
     }
 
     public void logEidasAttributesAsHash(
             HubResponseTranslatorRequestInterface hubResponseTranslatorRequest,
-            TranslatedHubResponseInterface translatedHubResponse
-    ) {
+            TranslatedHubResponseInterface translatedHubResponse) {
         EidasResponseAttributesHashLogger hashLogger = loggerSupplier.get();
         NonMatchingAttributes attributes = translatedHubResponse.getAttributes();
 
@@ -63,8 +61,7 @@ public class EidasAttributesLogger {
             EidasResponseAttributesHashLogger hashLogger,
             NonMatchingAttributes attributes,
             String requestId,
-            String destination
-    ) {
+            String destination) {
         if (attributes != null) {
             attributes.getFirstNames().stream()
                     .filter(NonMatchingVerifiableAttribute::isVerified)

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAttributesLogger.java
@@ -11,6 +11,7 @@ import uk.gov.ida.verifyserviceprovider.mappers.MatchingDatasetToNonMatchingAttr
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
 import uk.gov.ida.verifyserviceprovider.dto.NonMatchingVerifiableAttribute;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -26,18 +27,19 @@ public class EidasAttributesLogger {
     }
 
     public void logEidasAttributesAsHash(
-            HubResponseTranslatorRequestInterface hubResponseTranslatorRequest,
-            TranslatedHubResponseInterface translatedHubResponse) {
+            NonMatchingAttributes attributes,
+            String pid,
+            String requestId,
+            URI destination) {
         EidasResponseAttributesHashLogger hashLogger = loggerSupplier.get();
-        NonMatchingAttributes attributes = translatedHubResponse.getAttributes();
 
-        hashLogger.setPid(translatedHubResponse.getPid());
+        hashLogger.setPid(pid);
 
         updateLoggerAndLog(
                 hashLogger,
                 attributes,
-                hubResponseTranslatorRequest.getRequestId(),
-                hubResponseTranslatorRequest.getDestinationUrl().toString()
+                requestId,
+                destination.toString()
         );
     }
 

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasResponseAttributesHashLogger.java
@@ -36,7 +36,6 @@ public class EidasResponseAttributesHashLogger {
         responseAttributes = new ResponseAttributes();
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-
     }
 
     public static EidasResponseAttributesHashLogger instance() {

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HubResponseTranslatorRequestInterface.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HubResponseTranslatorRequestInterface.java
@@ -1,8 +1,0 @@
-package uk.gov.ida.eidas.logging;
-
-import java.net.URI;
-
-public interface HubResponseTranslatorRequestInterface {
-    String getRequestId();
-    URI getDestinationUrl();
-}

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/TranslatedHubResponseInterface.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/TranslatedHubResponseInterface.java
@@ -1,8 +1,0 @@
-package uk.gov.ida.eidas.logging;
-
-import uk.gov.ida.verifyserviceprovider.dto.NonMatchingAttributes;
-
-public interface TranslatedHubResponseInterface {
-    String getPid();
-    NonMatchingAttributes getAttributes();
-}

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
@@ -79,8 +79,8 @@ public class EidasAttributesLoggerTest {
     private String requestId = "requestId";
     private String issuerId = "issuer";
     private URI destination = URI.create("http://destination");
-    private EidasAttributesLogger proxyNodeEidasAttributesLogger;
-    private EidasAttributesLogger hubEidasAttributesLogger;
+    private EidasAttributesLogger preExtractedEidasAttributesLogger;
+    private EidasAttributesLogger assertionContainedEidasAttributesLogger;
 
     @Before
     public void setUp() {
@@ -105,11 +105,11 @@ public class EidasAttributesLoggerTest {
         when(assertion.getSubject()).thenReturn(subject);
         when(assertion.getIssuer()).thenReturn(issuer);
 
-        proxyNodeEidasAttributesLogger = new EidasAttributesLogger(
+        preExtractedEidasAttributesLogger = new EidasAttributesLogger(
                 () -> hashLogger,
                 null
         );
-        hubEidasAttributesLogger = new EidasAttributesLogger(
+        assertionContainedEidasAttributesLogger = new EidasAttributesLogger(
                 () -> hashLogger,
                 new UserIdHashFactory(entityId)
         );
@@ -125,7 +125,7 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getFirstNames()).thenReturn(firstNames);
 
-        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setFirstName("Paul");
@@ -152,7 +152,7 @@ public class EidasAttributesLoggerTest {
                 IdaConstants.Attributes_1_1.Firstname.NAME
         );
 
-        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        assertionContainedEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setFirstName("Paul");
@@ -170,7 +170,7 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getFirstNames()).thenReturn(firstNames);
 
-        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger, never()).setFirstName(any());
@@ -197,7 +197,7 @@ public class EidasAttributesLoggerTest {
                 IdaConstants.Attributes_1_1.Firstname.NAME
         );
 
-        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        assertionContainedEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger, never()).setFirstName(any());
@@ -215,7 +215,7 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getDatesOfBirth()).thenReturn(datesOfBirth);
 
-        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setDateOfBirth(LocalDate.of(1943, 2, 25));
@@ -242,7 +242,7 @@ public class EidasAttributesLoggerTest {
                 IdaConstants.Attributes_1_1.DateOfBirth.NAME
         );
 
-        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        assertionContainedEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setDateOfBirth(LocalDate.of(1943, 2, 25));
@@ -260,7 +260,7 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getMiddleNames()).thenReturn(middleNames);
 
-        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);
@@ -293,7 +293,7 @@ public class EidasAttributesLoggerTest {
                 IdaConstants.Attributes_1_1.Middlename.NAME
         );
 
-        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        assertionContainedEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);
@@ -314,7 +314,7 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getSurnames()).thenReturn(surnames);
 
-        proxyNodeEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);
@@ -347,7 +347,7 @@ public class EidasAttributesLoggerTest {
                 IdaConstants.Attributes_1_1.Surname.NAME
         );
 
-        hubEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        assertionContainedEidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAttributesLoggerTest.java
@@ -43,12 +43,6 @@ public class EidasAttributesLoggerTest {
     private EidasResponseAttributesHashLogger hashLogger;
 
     @Mock
-    private HubResponseTranslatorRequestInterface hubResponseTranslatorRequest;
-
-    @Mock
-    private TranslatedHubResponseInterface translatedHubResponse;
-
-    @Mock
     private NonMatchingAttributes attributes;
 
     @Mock
@@ -84,12 +78,6 @@ public class EidasAttributesLoggerTest {
 
     @Before
     public void setUp() {
-        when(translatedHubResponse.getAttributes()).thenReturn(attributes);
-        when(translatedHubResponse.getPid()).thenReturn(hashedPid);
-
-        when(hubResponseTranslatorRequest.getRequestId()).thenReturn(requestId);
-        when(hubResponseTranslatorRequest.getDestinationUrl()).thenReturn(destination);
-
         when(response.getInResponseTo()).thenReturn(requestId);
         when(response.getDestination()).thenReturn(destination.toString());
 
@@ -125,7 +113,12 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getFirstNames()).thenReturn(firstNames);
 
-        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(
+                attributes,
+                hashedPid,
+                requestId,
+                destination
+        );
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setFirstName("Paul");
@@ -170,7 +163,12 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getFirstNames()).thenReturn(firstNames);
 
-        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(
+                attributes,
+                hashedPid,
+                requestId,
+                destination
+        );
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger, never()).setFirstName(any());
@@ -215,7 +213,12 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getDatesOfBirth()).thenReturn(datesOfBirth);
 
-        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(
+                attributes,
+                hashedPid,
+                requestId,
+                destination
+        );
 
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setDateOfBirth(LocalDate.of(1943, 2, 25));
@@ -260,7 +263,12 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getMiddleNames()).thenReturn(middleNames);
 
-        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(
+                attributes,
+                hashedPid,
+                requestId,
+                destination
+        );
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);
@@ -314,7 +322,12 @@ public class EidasAttributesLoggerTest {
 
         when(attributes.getSurnames()).thenReturn(surnames);
 
-        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(hubResponseTranslatorRequest, translatedHubResponse);
+        preExtractedEidasAttributesLogger.logEidasAttributesAsHash(
+                attributes,
+                hashedPid,
+                requestId,
+                destination
+        );
 
         InOrder inOrder = inOrder(hashLogger);
         verify(hashLogger).setPid(hashedPid);


### PR DESCRIPTION
Saml-lib shouldn't need to know anything about the proxy-node and having
the interfaces tied it strongly to the proxy-node. We can instead
just pass in the objects we need from within the relevant objects.