### PR TITLE
EID-1762 Refactor NonMatchingAttributes fields

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingAttributes.java
@@ -15,17 +15,17 @@ import java.util.stream.Collectors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class NonMatchingAttributes {
     @JsonProperty("firstNames")
-    private final List<NonMatchingTransliterableAttribute> firstNames;
+    protected final List<NonMatchingTransliterableAttribute> firstNames;
     @JsonProperty("middleNames")
-    private final List<NonMatchingVerifiableAttribute<String>> middleNames;
+    protected final List<NonMatchingVerifiableAttribute<String>> middleNames;
     @JsonProperty("surnames")
-    private final List<NonMatchingTransliterableAttribute> surnames;
+    protected final List<NonMatchingTransliterableAttribute> surnames;
     @JsonProperty("datesOfBirth")
-    private final List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth;
+    protected final List<NonMatchingVerifiableAttribute<LocalDate>> datesOfBirth;
     @JsonProperty("gender")
-    private final NonMatchingVerifiableAttribute<Gender> gender;
+    protected final NonMatchingVerifiableAttribute<Gender> gender;
     @JsonProperty("addresses")
-    private final List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses;
+    protected final List<NonMatchingVerifiableAttribute<NonMatchingAddress>> addresses;
 
 
     @JsonCreator

--- a/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
+++ b/saml-lib/src/main/java/uk/gov/ida/verifyserviceprovider/dto/NonMatchingVerifiableAttribute.java
@@ -47,7 +47,7 @@ public class NonMatchingVerifiableAttribute<T> {
     }
 
     public boolean isCurrent() {
-        return (this.from != null && this.from.isBefore(LocalDate.now())) &&
+        return (this.from == null || this.from.isBefore(LocalDate.now())) &&
                 (this.to == null || this.to.isAfter(LocalDate.now()));
     }
 


### PR DESCRIPTION
These changes are to facilitate this proxy-node PR: https://github.com/alphagov/verify-proxy-node/pull/381

The class has been extended in the proxy-node and proxy-node specific
methods added. Making the fields protected allows that sub-class access
to them.

This also updates the way `isCurrent` of a
`NonMatchingVerifiableAttribute` is determined. This reflects recent
work done in the proxy-node: https://github.com/alphagov/verify-proxy-node/pull/364/file