### PR TITLE
Correct jq to fetch codacy coverage jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jdk:
 
 before_install:
   - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
+  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | contains("codacy-coverage-reporter-assembly"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
The structure of json at https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest has changed.

We use this document to find a download url for a required codacy coverage jar.

Update the jq search for this download url.

Taken from Hub: https://github.com/alphagov/verify-hub/pull/415/commits/2509303e344dca60f5623abfb0dd5aa9cf68c405