### PR TITLE
EID-1944 latest verify-dev-pki

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
                     'org.assertj:assertj-joda-time:2.2.0',
                     'org.assertj:assertj-core:3.14.0',
                     'org.junit.jupiter:junit-jupiter-api:5.5.2',
-                    'uk.gov.ida:ida-dev-pki:1.1.0-37',
+                    'uk.gov.ida:ida-dev-pki:1.2.0-10',
                     'org.mockito:mockito-core:3.2.0'
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"

--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/CertificateChainValidationFilterTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/CertificateChainValidationFilterTest.java
@@ -4,7 +4,6 @@ import certificates.values.CACertificates;
 import keystore.KeyStoreRule;
 import keystore.builders.KeyStoreRuleBuilder;
 import net.shibboleth.utilities.java.support.xml.BasicParserPool;
-import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +21,8 @@ import uk.gov.ida.saml.metadata.test.factories.metadata.EntityDescriptorFactory;
 import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 
 import javax.xml.namespace.QName;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -144,7 +145,7 @@ public class CertificateChainValidationFilterTest {
     private XMLObject validateMetadata(final CertificateChainValidationFilter certificateChainValidationFilter, String metadataContent) throws Exception {
         BasicParserPool parserPool = new BasicParserPool();
         parserPool.initialize();
-        XMLObject metadata = XMLObjectSupport.unmarshallFromInputStream(parserPool, IOUtils.toInputStream(metadataContent));
+        XMLObject metadata = XMLObjectSupport.unmarshallFromInputStream(parserPool, new ByteArrayInputStream(metadataContent.getBytes()));
         return certificateChainValidationFilter.filter(metadata);
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProviderTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/PKIXSignatureValidationFilterProviderTest.java
@@ -5,7 +5,6 @@ import certificates.values.CACertificates;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.xml.XMLObject;
@@ -25,6 +24,8 @@ import uk.gov.ida.saml.metadata.test.factories.metadata.EntitiesDescriptorFactor
 import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 import uk.gov.ida.saml.metadata.test.factories.metadata.TestCredentialFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -51,7 +52,7 @@ public class PKIXSignatureValidationFilterProviderTest {
         List<Certificate> certificateList = new ArrayList<>();
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
         for (String certificate : certificates) {
-            Certificate cert = certificateFactory.generateCertificate(IOUtils.toInputStream(certificate));
+            Certificate cert = certificateFactory.generateCertificate(new ByteArrayInputStream(certificate.getBytes()));
             certificateList.add(cert);
         }
 
@@ -167,7 +168,7 @@ public class PKIXSignatureValidationFilterProviderTest {
     private XMLObject validateMetadata(String metadataContent) throws XMLParserException, UnmarshallingException, FilterException, ComponentInitializationException {
         BasicParserPool parserPool = new BasicParserPool();
         parserPool.initialize();
-        XMLObject metadata = XMLObjectSupport.unmarshallFromInputStream(parserPool, IOUtils.toInputStream(metadataContent));
+        XMLObject metadata = XMLObjectSupport.unmarshallFromInputStream(parserPool, new ByteArrayInputStream(metadataContent.getBytes()));
         return signatureValidationFilter.filter(metadata);
     }
 


### PR DESCRIPTION
Use the latest verify-dev-pki which has test elliptic curve certs and keys.
Commons IOUtils no longer on classpath, so remove use and create an inputstream directly.