### PR TITLE
EID-1980 log Hub request id instead of pid from IDP

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashLogger.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashLogger.java
@@ -51,16 +51,16 @@ public final class EidasAuthnResponseAttributesHashLogger {
     private EidasAuthnResponseAttributesHashLogger() {
     }
 
-    public static void logEidasAttributesHash(NonMatchingAttributes attributes, String pid, String requestId, URI destination) {
-        logExtractedAttributes(attributes, requestId, destination.toString(), pid);
+    public static void logEidasAttributesHash(NonMatchingAttributes attributes, String requestId, URI destination) {
+        logExtractedAttributes(attributes, requestId, destination.toString());
     }
 
     public static void logEidasAttributesHash(Assertion assertion, Response response, String hashingEntityId) {
         final NonMatchingAttributes attributes = MATCHING_DATASET_MAPPER.mapToNonMatchingAttributes(MATCHING_DATASET_UNMARSHALLER.fromAssertion(assertion));
-        logExtractedAttributes(attributes, response.getInResponseTo(), response.getDestination(), getHashedPid(assertion, hashingEntityId));
+        logExtractedAttributes(attributes, response.getInResponseTo(), response.getDestination());
     }
 
-    private static void logExtractedAttributes(NonMatchingAttributes attributes, String requestId, String destination, String pid) {
+    private static void logExtractedAttributes(NonMatchingAttributes attributes, String requestId, String destination) {
         final HashableResponseAttributes attributesToHash = new HashableResponseAttributes();
 
         if (attributes != null) {
@@ -83,16 +83,8 @@ public final class EidasAuthnResponseAttributesHashLogger {
                     .ifPresent(dateOfBirth -> attributesToHash.setDateOfBirth(dateOfBirth.getValue()));
         }
 
-        attributesToHash.setPid(pid);
+        attributesToHash.setRequestId(requestId);
         logHash(requestId, destination, attributesToHash);
-    }
-
-    private static String getHashedPid(Assertion assertion, String hashingEntityId) {
-        return UserIdHashFactory.hashId(
-                hashingEntityId,
-                assertion.getIssuer().getValue(),
-                assertion.getSubject().getNameID().getValue(),
-                Optional.of(AuthnContext.LEVEL_2));
     }
 
     private static void logHash(String requestId, String destination, HashableResponseAttributes responseAttributes) {

--- a/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HashableResponseAttributes.java
+++ b/saml-lib/src/main/java/uk/gov/ida/eidas/logging/HashableResponseAttributes.java
@@ -11,11 +11,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder(value = {"pid", "firstName", "middleNames", "surnames", "dateOfBirth"})
+@JsonPropertyOrder(value = {"requestId", "firstName", "middleNames", "surnames", "dateOfBirth"})
 final class HashableResponseAttributes implements Serializable {
 
     @JsonProperty
-    private String pid;
+    private String requestId;
 
     @JsonProperty
     private String firstName;
@@ -30,8 +30,8 @@ final class HashableResponseAttributes implements Serializable {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate dateOfBirth;
 
-    public void setPid(String pid) {
-        this.pid = pid;
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
     }
 
     public void setFirstName(String firstName) {

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashBuilderTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashBuilderTest.java
@@ -42,7 +42,7 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
         final LocalDate now = LocalDate.now();
 
         final HashableResponseAttributes responseAttributes1 = new HashableResponseAttributes();
-        responseAttributes1.setPid("a");
+        responseAttributes1.setRequestId("a");
         responseAttributes1.setFirstName("fn");
         responseAttributes1.addMiddleName("mn");
         responseAttributes1.addSurname("sn");
@@ -50,7 +50,7 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
         final String hash1 = buildHash(responseAttributes1);
 
         final HashableResponseAttributes responseAttributes2 = new HashableResponseAttributes();
-        responseAttributes2.setPid("different pid");
+        responseAttributes2.setRequestId("different pid");
         responseAttributes2.setFirstName("fn");
         responseAttributes2.addMiddleName("mn");
         responseAttributes2.addSurname("sn");
@@ -65,7 +65,7 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
         final LocalDate now = LocalDate.now();
 
         final HashableResponseAttributes responseAttributes1 = new HashableResponseAttributes();
-        responseAttributes1.setPid("a");
+        responseAttributes1.setRequestId("a");
         responseAttributes1.setFirstName("fn");
         responseAttributes1.addMiddleName("mn");
         responseAttributes1.addSurname("sn");
@@ -73,7 +73,7 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
         final String hash1 = buildHash(responseAttributes1);
 
         final HashableResponseAttributes responseAttributes2 = new HashableResponseAttributes();
-        responseAttributes2.setPid("a");
+        responseAttributes2.setRequestId("a");
         responseAttributes2.setFirstName("fn");
         responseAttributes2.addMiddleName("mn");
         responseAttributes2.addSurname("sn");
@@ -103,10 +103,10 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
     @Test
     public void testUpdatingFieldsChangesHash() {
         final HashableResponseAttributes responseAttributes = new HashableResponseAttributes();
-        responseAttributes.setPid("a");
+        responseAttributes.setRequestId("a");
         final String hash1 = buildHash(responseAttributes);
 
-        responseAttributes.setPid("b");
+        responseAttributes.setRequestId("b");
         assertThat(hash1).isNotEqualTo(buildHash(responseAttributes));
     }
 
@@ -116,7 +116,7 @@ public class EidasAuthnResponseAttributesHashBuilderTest {
         logger.addAppender(appender);
 
         final HashableResponseAttributes responseAttributes = new HashableResponseAttributes();
-        responseAttributes.setPid("a");
+        responseAttributes.setRequestId("a");
 
         final String hash = buildHash(responseAttributes);
         logHash(responseAttributes);

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashLoggerTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/EidasAuthnResponseAttributesHashLoggerTest.java
@@ -15,7 +15,6 @@ import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
-import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Subject;
@@ -70,16 +69,12 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
     private Subject subject;
 
     @Mock
-    private Issuer issuer;
-
-    @Mock
     private Assertion assertion;
 
     private List<Attribute> attributes;
 
     private final LocalDate now = LocalDate.now();
     private final String entityId = "entityId";
-    private final String hashedPid = "f5f02791bb8eb83e81759b6f1ee744795048c2b45484842e403a42034fddd2c9";
     private final String unHashedPid = "unHashedPid";
     private final String requestId = "requestId";
     private final String issuerId = "issuer";
@@ -100,11 +95,8 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
 
         when(subject.getNameID()).thenReturn(nameID);
 
-        when(issuer.getValue()).thenReturn(issuerId);
-
         when(assertion.getAttributeStatements()).thenReturn(singletonList(attributeStatement));
         when(assertion.getSubject()).thenReturn(subject);
-        when(assertion.getIssuer()).thenReturn(issuer);
     }
 
     @Test
@@ -115,7 +107,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("George", "George", true, now, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.setFirstName("George");
 
         checkThatSameHashesAreLoggedForBothMethods(firstNames, null, null, null, validAttributesToHash);
@@ -129,7 +121,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("George", "George", true, null, null));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.setFirstName("Paul");
 
         checkThatSameHashesAreLoggedForBothMethods(firstNames, null, null, null, validAttributesToHash);
@@ -143,7 +135,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("George", "George", false, now, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
 
         checkThatSameHashesAreLoggedForBothMethods(firstNames, null, null, null, validAttributesToHash);
     }
@@ -156,7 +148,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingVerifiableAttribute<>(LocalDate.of(1943, 2, 25), true, now, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.setDateOfBirth(LocalDate.of(1943, 2, 25));
 
         checkThatSameHashesAreLoggedForBothMethods(null, datesOfBirth, null, null, validAttributesToHash);
@@ -170,7 +162,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingVerifiableAttribute<>("Carl", false, now, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.addMiddleName("Winston");
         validAttributesToHash.addMiddleName("James");
         validAttributesToHash.addMiddleName("Carl");
@@ -186,7 +178,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingVerifiableAttribute<>("Carl", true, null, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.addMiddleName("Carl");
         validAttributesToHash.addMiddleName("James");
         validAttributesToHash.addMiddleName("Winston");
@@ -202,7 +194,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("Harrison", "Harrison", true, now, now));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.addSurname("McCartney");
         validAttributesToHash.addSurname("Lennon");
         validAttributesToHash.addSurname("Harrison");
@@ -218,7 +210,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("Harrison", "Harrison", true, now, null));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.addSurname("Harrison");
         validAttributesToHash.addSurname("Lennon");
         validAttributesToHash.addSurname("McCartney");
@@ -249,7 +241,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
                 new NonMatchingTransliterableAttribute("Harrison", "Harrison", true, now, null));
 
         final HashableResponseAttributes validAttributesToHash = new HashableResponseAttributes();
-        validAttributesToHash.setPid(hashedPid);
+        validAttributesToHash.setRequestId(requestId);
         validAttributesToHash.setFirstName("George");
         validAttributesToHash.setDateOfBirth(LocalDate.of(1943, 2, 25));
         validAttributesToHash.addMiddleName("Carl");
@@ -289,7 +281,7 @@ public class EidasAuthnResponseAttributesHashLoggerTest {
             addAssertionContainedAttributes(surnames, PersonName.class, IdaConstants.Attributes_1_1.Surname.NAME);
         }
 
-        EidasAuthnResponseAttributesHashLogger.logEidasAttributesHash(preExtractedAttributes, hashedPid, requestId, destination);
+        EidasAuthnResponseAttributesHashLogger.logEidasAttributesHash(preExtractedAttributes, requestId, destination);
         verify(appender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         final String preExtractedAttributesHash = loggingEventArgumentCaptor.getValue().getMDCPropertyMap().get(MDC_KEY_EIDAS_USER_HASH);
 

--- a/saml-lib/src/test/java/uk/gov/ida/eidas/logging/HashableResponseAttributesTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/eidas/logging/HashableResponseAttributesTest.java
@@ -21,7 +21,7 @@ public class HashableResponseAttributesTest {
     public void shouldBeSerialisedToStringCorrectly() throws JsonProcessingException {
         final HashableResponseAttributes responseAttributes = new HashableResponseAttributes();
         LocalDate dateOfBirth = LocalDate.of(2019, 3, 24);
-        responseAttributes.setPid("a");
+        responseAttributes.setRequestId("a");
         responseAttributes.setFirstName("fn");
         responseAttributes.addMiddleName("m1");
         responseAttributes.addMiddleName("mn2");
@@ -29,7 +29,7 @@ public class HashableResponseAttributesTest {
         responseAttributes.setDateOfBirth(dateOfBirth);
 
         final String attributesString = OBJECT_MAPPER.writeValueAsString(responseAttributes);
-        final String expectedAttributesString = "{\"pid\":\"a\",\"firstName\":\"fn\",\"middleNames\":[\"m1\",\"mn2\"],\"surnames\":[\"sn\"],\"dateOfBirth\":\"2019-03-24\"}";
+        final String expectedAttributesString = "{\"requestId\":\"a\",\"firstName\":\"fn\",\"middleNames\":[\"m1\",\"mn2\"],\"surnames\":[\"sn\"],\"dateOfBirth\":\"2019-03-24\"}";
 
         assertThat(attributesString).isEqualTo(expectedAttributesString);
     }
@@ -37,12 +37,12 @@ public class HashableResponseAttributesTest {
     @Test
     public void shouldBeSerialisedToStringCorrectlyWithMinimumAttributeSet() throws JsonProcessingException {
         final HashableResponseAttributes responseAttributes = new HashableResponseAttributes();
-        responseAttributes.setPid("a");
+        responseAttributes.setRequestId("a");
         responseAttributes.setFirstName("fn");
         responseAttributes.addSurname("sn");
 
         final String attributesString = OBJECT_MAPPER.writeValueAsString(responseAttributes);
-        final String expectedAttributesString = "{\"pid\":\"a\",\"firstName\":\"fn\",\"surnames\":[\"sn\"]}";
+        final String expectedAttributesString = "{\"requestId\":\"a\",\"firstName\":\"fn\",\"surnames\":[\"sn\"]}";
 
         assertThat(attributesString).isEqualTo(expectedAttributesString);
     }


### PR DESCRIPTION
To mitigate against fraud, we log the hash of user attributes for an eIDAS journey in the Hub and in Proxy Node Translator. If these hashes do do match there may have been tampering of identities.

Currently, the user’s PID from the IDP is included in the hash. However, as we need to support “transient” PIDs for eIDAS, it means that we will send a different PID back to the requesting the country than what we received from the IDP. This means that we’ll be sending an identity with a different hash to what we had logged, which means that we won’t be able to tell if the identity has been tampered with in case there needs to be a fraud investigation.

To mitigate this, we will use the Proxy Node request ID generated by the VSP. This is the only common is we can use since it’s available both in the Hub and the Proxy Node.

Remove the PID string from the hash of eIDAS user attributes we log in hub saml-engine and proxy node translator. Instead log the hub request id generated by the VSP.