### PR TITLE
EID-1984 Create a MetadataResolverBundle w/o healthcheck

### DIFF
--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataBundleTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataBundleTest.java
@@ -99,7 +99,7 @@ public class FederationMetadataBundleTest {
         @Override
         public void initialize(Bootstrap<TestConfiguration> bootstrap) {
             super.initialize(bootstrap);
-            bundle = new MetadataResolverBundle<>(TestConfiguration::getMetadataConfiguration);
+            bundle = new MetadataResolverBundle.Builder<>(TestConfiguration::getMetadataConfiguration).build();
             bootstrap.addBundle(bundle);
         }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataWithoutTrustStoresBundleTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/FederationMetadataWithoutTrustStoresBundleTest.java
@@ -92,7 +92,7 @@ public class FederationMetadataWithoutTrustStoresBundleTest {
         @Override
         public void initialize(Bootstrap<TestConfiguration> bootstrap) {
             super.initialize(bootstrap);
-            bundle = new MetadataResolverBundle<>(TestConfiguration::getMetadataConfiguration);
+            bundle = new MetadataResolverBundle.Builder<>(TestConfiguration::getMetadataConfiguration).build();
             bootstrap.addBundle(bundle);
         }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundleTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/bundle/MetadataResolverBundleTest.java
@@ -1,0 +1,120 @@
+package uk.gov.ida.saml.metadata.bundle;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
+import uk.gov.ida.saml.metadata.factories.CredentialResolverFactory;
+import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
+import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataResolverBundleTest {
+
+    @Mock
+    private MetadataResolverConfiguration configuration;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private CredentialResolverFactory credentialResolverFactory;
+
+    @Mock
+    private DropwizardMetadataResolverFactory dropwizardMetadataResolverFactory;
+
+    @Mock
+    private MetadataSignatureTrustEngineFactory metadataSignatureTrustEngineFactory;
+
+    @Mock
+    private MetadataResolver metadataResolver;
+
+    @Mock
+    private ExplicitKeySignatureTrustEngine signatureTrustEngine;
+
+    @Mock
+    private MetadataCredentialResolver credentialResolver;
+
+    @Mock
+    private HealthCheckRegistry healthCheckRegistry;
+
+    @Test
+    public void shouldValidateSignatureAndRegisterHealthcheckWithDefaultBuilder() throws Exception {
+
+        MetadataResolverBundle bundle = new MetadataResolverBundle.Builder<>(TestConfiguration::getMetadataConfiguration)
+                .withCredentialResolverFactory(credentialResolverFactory)
+                .withDropwizardMetadataResolverFactory(dropwizardMetadataResolverFactory)
+                .withMetadataSignatureTrustEngineFactory(metadataSignatureTrustEngineFactory)
+                .build();
+
+        when(dropwizardMetadataResolverFactory.createMetadataResolver(environment, configuration, true))
+                .thenReturn(metadataResolver);
+        when(metadataSignatureTrustEngineFactory.createSignatureTrustEngine(metadataResolver))
+                .thenReturn(signatureTrustEngine);
+        when(credentialResolverFactory.create(metadataResolver))
+                .thenReturn(credentialResolver);
+        when(environment.healthChecks()).thenReturn(healthCheckRegistry);
+        when(configuration.getUri()).thenReturn(URI.create("http://entity.id"));
+
+        bundle.run(new TestConfiguration(configuration), environment);
+
+        verify(environment).healthChecks();
+        verify(healthCheckRegistry).register(eq("http://entity.id"), any(HealthCheck.class));
+
+    }
+
+
+    @Test
+    public void shouldNotRegisterHealthcheckWhenBundleBuiltWithHealthchecksFalse() throws Exception {
+
+        MetadataResolverBundle bundle = new MetadataResolverBundle.Builder<>(TestConfiguration::getMetadataConfiguration)
+                .withCredentialResolverFactory(credentialResolverFactory)
+                .withDropwizardMetadataResolverFactory(dropwizardMetadataResolverFactory)
+                .withMetadataSignatureTrustEngineFactory(metadataSignatureTrustEngineFactory)
+                .withHealthcheck(false)
+                .build();
+
+        when(dropwizardMetadataResolverFactory.createMetadataResolver(environment, configuration, true))
+                .thenReturn(metadataResolver);
+        when(metadataSignatureTrustEngineFactory.createSignatureTrustEngine(metadataResolver))
+                .thenReturn(signatureTrustEngine);
+        when(credentialResolverFactory.create(metadataResolver))
+                .thenReturn(credentialResolver);
+
+        bundle.run(new TestConfiguration(configuration), environment);
+
+        verify(environment, never()).healthChecks();
+
+    }
+
+    class TestConfiguration extends Configuration {
+
+        private final MetadataResolverConfiguration metadataConfiguration;
+
+        TestConfiguration(MetadataResolverConfiguration metadataConfiguration) {
+            this.metadataConfiguration = metadataConfiguration;
+        }
+
+        Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+            return Optional.of(metadataConfiguration);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR will allow us to configure the Proxy Node Stub-Connector to have a MetadataResolverBundle that does not perform healthchecks. If a pod fails a healthcheck, k8s will restart it, which is not desired behaviour in our environment.

* Configure a MetadataResolverBundle without a healthcheck.
* Add tests for MetadataResolverBundle.
* Introduce a Builder pattern instead of expanding the constructor of MetadataResolverBundle to accept another boolean.
* the Builder pattern optionally allows mocks to be part of the build, which makes unit testing easy.