### PR TITLE
EID-1977 get namespaces on a validated response

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/validators/ValidatedResponse.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/validators/ValidatedResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.saml.security.validators;
 
 import org.joda.time.DateTime;
+import org.opensaml.core.xml.Namespace;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
@@ -9,6 +10,7 @@ import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.xmlsec.signature.Signature;
 
 import java.util.List;
+import java.util.Set;
 
 public class ValidatedResponse implements ValidatedEncryptedAssertionContainer {
     private Response response;
@@ -45,6 +47,10 @@ public class ValidatedResponse implements ValidatedEncryptedAssertionContainer {
 
     public String getDestination() {
         return response.getDestination();
+    }
+
+    public Set<Namespace> getNamespaces() {
+        return response.getNamespaces();
     }
 
     @Override


### PR DESCRIPTION
We want to evaluate the namespaces on a valid reponse for PR https://github.com/alphagov/verify-hub/pull/454.

This provides that non null set of namespaces.