### PR TITLE
BAU - Utility class to encapsulate Base64 actions

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/Base64.java
+++ b/saml-lib/src/main/java/uk/gov/ida/Base64.java
@@ -1,0 +1,69 @@
+package uk.gov.ida;
+
+public class Base64 {
+    public static byte[] decodeToByteArray(String base64) {
+        return java.util.Base64.getDecoder().decode(base64);
+    }
+
+    public static byte[]  decodeToByteArray(byte[] base64) {
+        return java.util.Base64.getDecoder().decode(base64);
+    }
+
+    public static String decodeToString(String base64) {
+        return new String(java.util.Base64.getDecoder().decode(base64));
+    }
+
+    public static String decodeToString(byte[] base64) {
+        return new String(java.util.Base64.getDecoder().decode(base64));
+    }
+
+    public static byte[] encodeToByteArray(String plain) {
+        return java.util.Base64.getEncoder().encode(plain.getBytes());
+    }
+
+    public static byte[] encodeToByteArray(byte[] plain) {
+        return java.util.Base64.getEncoder().encode(plain);
+    }
+
+    public static String encodeToString(String plain) {
+        return new String(java.util.Base64.getEncoder().encode(plain.getBytes()));
+    }
+
+    public static String encodeToString(byte[] plain) {
+        return new String(java.util.Base64.getEncoder().encode(plain));
+    }
+
+    public static class Mime {
+        public static byte[] decodeToByteArray(String base64) {
+            return java.util.Base64.getMimeDecoder().decode(base64);
+        }
+
+        public static byte[]  decodeToByteArray(byte[] base64) {
+            return java.util.Base64.getMimeDecoder().decode(base64);
+        }
+
+        public static String decodeToString(String base64) {
+            return new String(java.util.Base64.getMimeDecoder().decode(base64));
+        }
+
+        public static String decodeToString(byte[] base64) {
+            return new String(java.util.Base64.getMimeDecoder().decode(base64));
+        }
+
+        public static byte[] encodeToByteArray(String plain) {
+            return java.util.Base64.getMimeEncoder().encode(plain.getBytes());
+        }
+
+        public static byte[] encodeToByteArray(byte[] plain) {
+            return java.util.Base64.getMimeEncoder().encode(plain);
+        }
+
+        public static String encodeToString(String plain) {
+            return new String(java.util.Base64.getMimeEncoder().encode(plain.getBytes()));
+        }
+
+        public static String encodeToString(byte[] plain) {
+            return new String(java.util.Base64.getMimeEncoder().encode(plain));
+        }
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/Base64Test.java
+++ b/saml-lib/src/test/java/uk/gov/ida/Base64Test.java
@@ -1,0 +1,96 @@
+package uk.gov.ida;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Base64Test {
+
+    private static final String STRING_PLAIN = "Ding dong, dingly dell, dibble dabble dooby.";
+    private static final String STRING_BASE64 = "RGluZyBkb25nLCBkaW5nbHkgZGVsbCwgZGliYmxlIGRhYmJsZSBkb29ieS4=";
+
+    private static final byte[] BYTES_PLAIN = STRING_PLAIN.getBytes();
+    private static final byte[] BYTES_BASE64 = STRING_BASE64.getBytes();
+
+    @Test
+    public void shouldDecodeToByteArrayFromString() {
+        assertThat(Base64.decodeToByteArray(STRING_BASE64)).isEqualTo(BYTES_PLAIN);
+    }
+
+    @Test
+    public void shouldDecodeToByteArrayFromByteArray() {
+        assertThat(Base64.decodeToByteArray(BYTES_BASE64)).isEqualTo(BYTES_PLAIN);
+    }
+
+    @Test
+    public void shouldDecodeToStringFromString() {
+        assertThat(Base64.decodeToString(STRING_BASE64)).isEqualTo(STRING_PLAIN);
+    }
+
+    @Test
+    public void shouldDecodeToStringFromByteArray() {
+        assertThat(Base64.decodeToString(BYTES_BASE64)).isEqualTo(STRING_PLAIN);
+    }
+
+    @Test
+    public void shouldEncodeToByteArrayFromString() {
+        assertThat(Base64.encodeToByteArray(STRING_PLAIN)).isEqualTo(BYTES_BASE64);
+    }
+
+    @Test
+    public void shouldEncodeToByteArrayFromByteArray() {
+        assertThat(Base64.encodeToByteArray(BYTES_PLAIN)).isEqualTo(BYTES_BASE64);
+    }
+
+    @Test
+    public void shouldEncodeToStringFromString() {
+        assertThat(Base64.encodeToString(STRING_PLAIN)).isEqualTo(STRING_BASE64);
+    }
+
+    @Test
+    public void shouldEncodeToStringFromByteArray() {
+        assertThat(Base64.encodeToString(BYTES_PLAIN)).isEqualTo(STRING_BASE64);
+    }
+
+/* MIME */
+
+    @Test
+    public void shouldMimeDecodeToByteArrayFromString() {
+        assertThat(Base64.Mime.decodeToByteArray(STRING_BASE64)).isEqualTo(BYTES_PLAIN);
+    }
+
+    @Test
+    public void shouldMimeDecodeToByteArrayFromByteArray() {
+        assertThat(Base64.Mime.decodeToByteArray(BYTES_BASE64)).isEqualTo(BYTES_PLAIN);
+    }
+
+    @Test
+    public void shouldMimeDecodeToStringFromString() {
+        assertThat(Base64.Mime.decodeToString(STRING_BASE64)).isEqualTo(STRING_PLAIN);
+    }
+
+    @Test
+    public void shouldMimeDecodeToStringFromByteArray() {
+        assertThat(Base64.Mime.decodeToString(BYTES_BASE64)).isEqualTo(STRING_PLAIN);
+    }
+
+    @Test
+    public void shouldMimeEncodeToByteArrayFromString() {
+        assertThat(Base64.Mime.encodeToByteArray(STRING_PLAIN)).isEqualTo(BYTES_BASE64);
+    }
+
+    @Test
+    public void shouldMimeEncodeToByteArrayFromByteArray() {
+        assertThat(Base64.Mime.encodeToByteArray(BYTES_PLAIN)).isEqualTo(BYTES_BASE64);
+    }
+
+    @Test
+    public void shouldMimeEncodeToStringFromString() {
+        assertThat(Base64.Mime.encodeToString(STRING_PLAIN)).isEqualTo(STRING_BASE64);
+    }
+
+    @Test
+    public void shouldMimeEncodeToStringFromByteArray() {
+        assertThat(Base64.Mime.encodeToString(BYTES_PLAIN)).isEqualTo(STRING_BASE64);
+    }
+}


### PR DESCRIPTION
The Verify / Proxy Node uses many of the different available libraries for Base64 encoding including `import org.glassfish.jersey.internal.util.Base64` which is a barrier to upgrading to Dropwizard 2.

This provides a facade to the java.util implementation so that the codebase can have one true base64 to rule them all.  Unfortunately saml-lib itself does some fairly funky stuff that includes injecting its own (overcooked?) base64 implementation so this immediately has a limitation (or rather there are more pressing things to do and I thought it would be much simpler) so that ironically, saml-lib doesn't use the base64 lib it provides at the moment.