### PR TITLE
HUB-697: Remove `NotNull` from TrustStoreBackedMetadataConfiguration

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/metadata/TrustStoreBackedMetadataConfiguration.java
@@ -14,7 +14,6 @@ import java.security.KeyStore;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TrustStoreBackedMetadataConfiguration extends MetadataConfiguration {
 
-    @NotNull
     @Valid
     private TrustStoreConfiguration trustStore;
 


### PR DESCRIPTION
This is to allow a default trust store configuration to be used in the
MSA. See this PR for details: https://github.com/alphagov/verify-matching-service-adapter/pull/159