### PR TITLE
BAU: Decrease trustAnchorMaxRefreshDelay

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfiguration.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataConfiguration.java
@@ -46,7 +46,7 @@ public class EidasMetadataConfiguration {
         this.minRefreshDelay = Optional.ofNullable(minRefreshDelay).orElse(60000L);
         this.maxRefreshDelay = Optional.ofNullable(maxRefreshDelay).orElse(600000L);
         this.trustAnchorMinRefreshDelay = Optional.ofNullable(trustAnchorMinRefreshDelay).orElse(60000L);
-        this.trustAnchorMaxRefreshDelay = Optional.ofNullable(trustAnchorMaxRefreshDelay).orElse(3600000L);
+        this.trustAnchorMaxRefreshDelay = Optional.ofNullable(trustAnchorMaxRefreshDelay).orElse(300000L);
         this.client = Optional.ofNullable(client).orElse(new JerseyClientConfiguration());
         this.jerseyClientName = Optional.ofNullable(jerseyClientName).orElse("MetadataClient");
         this.trustStore = trustStore;


### PR DESCRIPTION
This changes the period that the trust-anchors are polled from 1 hour to
5 minutes. If a new trust-anchor is published it means that something is
already probably broken and we don't want to wait an hour for it. One
request every 5 minutes is not excessive.

Also, changing the default will mean that there's no need to update
config files for the MSA/VSP or the hub.