### PR TITLE
BAU: Set max refresh delay before getting eIDAS trust anchor

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepository.java
@@ -64,6 +64,7 @@ public class EidasMetadataResolverRepository implements MetadataResolverReposito
         this.metadataSignatureTrustEngineFactory = metadataSignatureTrustEngineFactory;
         this.metadataResolverConfigBuilder = metadataResolverConfigBuilder;
         this.client = client;
+        setMinTrustAnchorRefreshDelay();
         refresh();
     }
 

--- a/saml-lib/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/metadata/EidasMetadataResolverRepositoryTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
+import java.util.TimerTask;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -391,6 +392,15 @@ public class EidasMetadataResolverRepositoryTest {
         verifyZeroInteractions(dropwizardMetadataResolverFactory);
         Map<String, MetadataResolver> refreshedMetadataResolvers = metadataResolverRepository.getMetadataResolvers();
         refreshedMetadataResolvers.forEach((key, value) -> assertThat(value == originalMetadataResolvers.get(key)).isTrue());
+    }
+
+    @Test
+    public void shouldBeInitializedWithMinRefreshDelay() throws CertificateException, SignatureException, ParseException, JOSEException {
+        when(metadataConfiguration.getTrustAnchorMinRefreshDelay()).thenReturn((long) 17);
+
+        createMetadataResolverRepositoryWithTrustAnchors();
+
+        verify(timer).schedule(any(TimerTask.class), eq((long) 17));
     }
 
     private EidasMetadataResolverRepository createMetadataResolverRepositoryWithTrustAnchors(JWK... trustAnchors) throws ParseException, CertificateException, JOSEException, SignatureException {


### PR DESCRIPTION
If there are no trust anchors in the JWT retrieved from the configured
trust anchor endpoint when the eIDAS metadata resolver starts up, the
`trustAnchorsAreDifferent` conditional check in the `refresh` method
will be false. This will cause the logic flow to skip directly to the `finally`
block. The `delayBeforeNextRefresh` field hasn't been explicitly set at 
this point and so is the default for a long, 0.

This causes the next refresh to happen immediately - as there is still
an issue with the trust anchor this pattern repeats hundreds of times a
second. The application logs fill up and it's very hard to diagnose