### PR TITLE
HUB-866: Ensure published libs have description

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -42,7 +42,7 @@ configure(subprojects.findAll {it.name != 'buildSrc'}) {
                 pom {
                     name = project.name
                     packaging = 'jar'
-                    description = project.description
+                    description = 'Library for ' + project.name
                     url = 'https://github.com/alphagov/verify-saml-libs'
                     artifactId = project.name
 


### PR DESCRIPTION
`project.description` was empty resulting in the description not being
added to the POM, and so Sonatype refusing to close the repo.