### PR TITLE
HUB-913: Pull from maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ dist: xenial
 
 jdk:
   - openjdk11
-  - openjdk8
 
 before_install:
   - sudo apt-get install jq

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-            jcenter()
+            mavenCentral()
         }
         else {
             maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -16,12 +16,11 @@ buildscript {
 plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 ext {
     opensaml_version = "3.4.3"
     dropwizard_version = "1.3.22"
-    ida_utils_version = "383"
+    ida_utils_version = "394"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -39,21 +38,20 @@ allprojects {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 subprojects {
     configurations.all {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
             maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-            jcenter()
+            mavenCentral()
         }
         else {
             maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -95,14 +93,14 @@ subprojects {
         security 'com.nimbusds:nimbus-jose-jwt:7.3',
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
-        test_deps   'uk.gov.ida:common-test-utils:2.0.0-54',
+        test_deps   'uk.gov.ida:common-test-utils:2.0.0-64',
                     'com.github.tomakehurst:wiremock-standalone:2.23.2',
                     "io.dropwizard:dropwizard-testing:$dropwizard_version",
                     'org.hamcrest:hamcrest-library:2.2',
                     'org.assertj:assertj-joda-time:2.2.0',
                     'org.assertj:assertj-core:3.14.0',
                     'org.junit.jupiter:junit-jupiter-api:5.5.2',
-                    'uk.gov.ida:ida-dev-pki:1.2.0-16',
+                    'uk.gov.ida:verify-dev-pki:2.0.0-45',
                     'org.mockito:mockito-core:3.2.0'
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"


### PR DESCRIPTION
This uses the maven central for public builds, and bumps versions to
make sure it's being used rather than bintray.

This requires the Java version to move from 8 to 11, as the only version
of rest-utils and common-utils available from maven central is compiled
with Java 11.