### PR TITLE
HUB-912: Downgrade to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 dist: xenial
 
 jdk:
+  - openjdk8
   - openjdk11
 
 before_install:

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,3 @@
-buildscript {
-    repositories {
-        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
-            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-            mavenCentral()
-        }
-        else {
-            maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
-        }
-    }
-    dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
-    }
-}
-
 plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
@@ -20,7 +5,7 @@ plugins {
 ext {
     opensaml_version = "3.4.3"
     dropwizard_version = "1.3.22"
-    ida_utils_version = "394"
+    ida_utils_version = "396"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -28,7 +13,6 @@ apply from: 'publish.gradle'
 
 allprojects {
     apply plugin: 'jacoco'
-    apply plugin: 'com.github.ben-manes.versions'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'java'
@@ -43,8 +27,10 @@ repositories {
 
 subprojects {
     configurations.all {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        // These are set to provide compatibility with the MSA and the VSP which need to stay on Java8 for services.
+        // Please don't bump unless we've agreed to release the MSA and VSP with a later version.
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     repositories {


### PR DESCRIPTION
The MSA and the VSP need to stay compatible with Java 8 for the sake of
services.

saml-lib is a direct dependency of the MSA and the VSP.

saml-lib needs to be published with Java 8 byte code or the MSA and the
VSP won't be able to use it.

This pulls in version 396 of the utils libs, which have also just been
downgraded to Java 8 for the same reason.

Also removes an old and unloved plugin.