### PR TITLE
HUB-942: Dropwizard -> 2, OpenSAML -> 3.4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 ext {
-    opensaml_version = "3.4.3"
-    dropwizard_version = "1.3.22"
-    ida_utils_version = "396"
+    opensaml_version = "3.4.6"
+    dropwizard_version = "2.0.21"
+    ida_utils_version = "397"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -79,15 +79,16 @@ subprojects {
         security 'com.nimbusds:nimbus-jose-jwt:7.3',
                 "uk.gov.ida:security-utils:2.0.0-$ida_utils_version"
 
-        test_deps   'uk.gov.ida:common-test-utils:2.0.0-64',
+        test_deps   'uk.gov.ida:common-test-utils:2.0.0-66',
                     'com.github.tomakehurst:wiremock-standalone:2.23.2',
                     "io.dropwizard:dropwizard-testing:$dropwizard_version",
                     'org.hamcrest:hamcrest-library:2.2',
                     'org.assertj:assertj-joda-time:2.2.0',
                     'org.assertj:assertj-core:3.14.0',
                     'org.junit.jupiter:junit-jupiter-api:5.5.2',
-                    'uk.gov.ida:verify-dev-pki:2.0.0-45',
-                    'org.mockito:mockito-core:3.2.0'
+                    'uk.gov.ida:verify-dev-pki:2.0.0-46',
+                    'org.mockito:mockito-core:3.2.0',
+                    "org.mockito:mockito-junit-jupiter:3.2.0"
 
         xml_utils "uk.gov.ida:common-utils:2.0.0-$ida_utils_version"
     }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/metadata/MetadataRefreshTask.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/metadata/MetadataRefreshTask.java
@@ -1,12 +1,13 @@
 package uk.gov.ida.saml.metadata;
 
-import com.google.common.collect.ImmutableMultimap;
 import io.dropwizard.servlets.tasks.Task;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
 
 import javax.inject.Inject;
 import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
 
 public class MetadataRefreshTask extends Task {
     private AbstractReloadingMetadataResolver metadataProvider;
@@ -18,7 +19,7 @@ public class MetadataRefreshTask extends Task {
     }
 
     @Override
-    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+    public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
         metadataProvider.refresh();
     }
 }

--- a/saml-test/src/main/java/uk/gov/ida/saml/core/test/OpenSAMLExtension.java
+++ b/saml-test/src/main/java/uk/gov/ida/saml/core/test/OpenSAMLExtension.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.saml.core.test;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.runners.model.InitializationError;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+
+public class OpenSAMLExtension implements BeforeAllCallback {
+    @Override
+    public void beforeAll(ExtensionContext context) throws InitializationError {
+        try {
+            IdaSamlBootstrap.bootstrap();
+        } catch (IdaSamlBootstrap.BootstrapException e) {
+            throw new InitializationError(e);
+        }
+    }
+}


### PR DESCRIPTION
**Can't be merged before: https://github.com/alphagov/verify-utils-libs/pull/63, https://github.com/alphagov/verify-test-utils/pull/19,**

This bumps dropwizard to 2, for use by the hub.

It bumps opensaml. The old version was dependant on an old version of
apach httpclient which was causing a class path clash in the hub.

It pulls in updated versions of our utils libraries - these are currently
set to SNAPSHOT as there are PR's on these libs waiting to be merged.

It also adds a new class, `OpenSAMLExtension`. This is a junit 5 extension
which does the job of bootstrapping Ida SAML. This is used extensively
in the hub tests.