### PR TITLE
HUB-1055: Add metric on IDP SAML response

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngine.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngine.java
@@ -1,0 +1,84 @@
+package uk.gov.ida.saml.security.signature;
+
+import com.google.common.base.Strings;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.criteria.KeyAlgorithmCriterion;
+import org.opensaml.security.criteria.UsageCriterion;
+import org.opensaml.xmlsec.algorithm.AlgorithmSupport;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.prometheus.client.Counter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class OutgoingKeySignatureTrustEngine extends ExplicitKeySignatureTrustEngine {
+    /**
+     * Constructor.
+     *
+     * @param resolver        credential resolver used to resolve trusted credentials.
+     * @param keyInfoResolver KeyInfo credential resolver used to obtain the (advisory) signing credential from a 
+     *                        trusted credential store
+     */
+    private final Logger log = LoggerFactory.getLogger(OutgoingKeySignatureTrustEngine.class);
+
+    private static final Counter outgoingSignatureVerifyingErrorCounter = Counter.build(
+                    "verify_saml_lib_signature_verifying_error_counter",
+                    "Counter to detect errors on the outgoing signature, reports the number of errors")
+            .labelNames("error_type")
+            .register();
+
+    public OutgoingKeySignatureTrustEngine(@Nonnull CredentialResolver resolver, @Nonnull KeyInfoCredentialResolver keyInfoResolver) {
+        super(resolver, keyInfoResolver);
+    }
+
+    @Override
+    protected boolean doValidate(@Nonnull final Signature signature,
+                                 @Nullable final CriteriaSet trustBasisCriteria) throws SecurityException {
+
+        final CriteriaSet criteriaSet = new CriteriaSet();
+        criteriaSet.addAll(trustBasisCriteria);
+        if (!criteriaSet.contains(UsageCriterion.class)) {
+            criteriaSet.add(new UsageCriterion(UsageType.SIGNING));
+        }
+        final String jcaAlgorithm = AlgorithmSupport.getKeyAlgorithm(signature.getSignatureAlgorithm());
+        if (!Strings.isNullOrEmpty(jcaAlgorithm)) {
+            criteriaSet.add(new KeyAlgorithmCriterion(jcaAlgorithm), true);
+        }
+
+        final Iterable<Credential> trustedCredentials;
+        try {
+            trustedCredentials = getCredentialResolver().resolve(criteriaSet);
+        } catch (final ResolverException e) {
+            throw new SecurityException("Error resolving trusted credentials", e);
+        }
+
+        if (validate(signature, trustedCredentials)) {
+            return true;
+        }
+
+        // If the credentials extracted from Signature's KeyInfo (if any) did not verify the
+        // signature and/or establish trust, as a fall back attempt verify the signature with
+        // the trusted credentials directly.
+        log.debug("Attempting to verify signature using trusted credentials");
+
+        for (final Credential trustedCredential : trustedCredentials) {
+            if (verifySignature(signature, trustedCredential)) {
+                log.debug("Successfully verified signature using resolved trusted credential");
+                return true;
+            }
+            outgoingSignatureVerifyingErrorCounter.labels("verification_failed").inc();
+            log.warn("Failed to verify signature using trusted credentials");
+        }
+        log.debug("Failed to verify signature using either KeyInfo-derived or directly trusted credentials");
+        return false;
+    }
+}

--- a/saml-lib/src/test/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngineTest.java
+++ b/saml-lib/src/test/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngineTest.java
@@ -1,0 +1,108 @@
+package uk.gov.ida.saml.security.signature;
+
+import io.prometheus.client.Counter;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.StaticCredentialResolver;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.security.saml.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.security.saml.TestCredentialFactory;
+import uk.gov.ida.saml.security.saml.builders.AssertionBuilder;
+import uk.gov.ida.saml.security.saml.builders.SignatureBuilder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class OutgoingKeySignatureTrustEngineTest {
+
+    @Test
+    public void shouldVerifyIdpWithAValidSigningCertificate() throws Exception {
+        final Credential outgoingSigningCredential = new TestCredentialFactory(
+                TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT,
+                TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY
+        ).getSigningCredential();
+        final CredentialResolver credentialResolver = new StaticCredentialResolver(
+                Collections.singletonList(outgoingSigningCredential)
+        );
+        final KeyInfoCredentialResolver keyInfoResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+
+        OutgoingKeySignatureTrustEngine trustEngine = new OutgoingKeySignatureTrustEngine(credentialResolver, keyInfoResolver);
+        
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(
+                new EntityIdCriterion(TestEntityIds.HUB_ENTITY_ID)
+        );
+        
+        Counter outgoingSignatureVerifyingErrorCounter = mock(Counter.class);
+        setFinalStatic(OutgoingKeySignatureTrustEngine.class.getDeclaredField("outgoingSignatureVerifyingErrorCounter"), outgoingSignatureVerifyingErrorCounter);
+
+        final Credential incomingSigningCredential = new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT, TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY).getSigningCredential();
+        final Assertion assertion = AssertionBuilder.anAssertion().withSignature(SignatureBuilder.aSignature().withSigningCredential(incomingSigningCredential).build()).build();
+
+        assertThat(trustEngine.doValidate(assertion.getSignature(), trustBasisCriteria)).isTrue();
+        verifyNoInteractions(outgoingSignatureVerifyingErrorCounter);
+    }
+    
+    @Test
+    public void shouldSendErrorCounterValidatingWithOutgoingSigningCertificate() throws Exception {
+        final Credential incomingSigningCredential = new TestCredentialFactory(
+                TestCertificateStrings.EXPIRED_SIGNING_PUBLIC_CERT,
+                TestCertificateStrings.EXPIRED_SIGNING_PRIVATE_KEY
+        ).getSigningCredential();
+        final Credential outgoingSigningCredential = new TestCredentialFactory(
+                TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT,
+                TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY
+        ).getSigningCredential();
+        final CredentialResolver credentialResolver = new StaticCredentialResolver(
+                Arrays.asList(incomingSigningCredential, outgoingSigningCredential)
+        );
+        final KeyInfoCredentialResolver keyInfoResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+
+        OutgoingKeySignatureTrustEngine trustEngine = new OutgoingKeySignatureTrustEngine(credentialResolver, keyInfoResolver);
+
+        CriteriaSet trustBasisCriteria = new CriteriaSet();
+        trustBasisCriteria.add(
+                new EntityIdCriterion(TestEntityIds.HUB_ENTITY_ID)
+        );
+        
+        Counter outgoingSignatureVerifyingErrorCounter = mock(Counter.class);
+        Counter.Child childCounter = mock(Counter.Child.class);
+        setFinalStatic(OutgoingKeySignatureTrustEngine.class.getDeclaredField("outgoingSignatureVerifyingErrorCounter"), outgoingSignatureVerifyingErrorCounter);
+
+        final Assertion outgoing_assertion = AssertionBuilder.anAssertion().withSignature(SignatureBuilder.aSignature().withSigningCredential(outgoingSigningCredential).build()).build();
+        
+        when(outgoingSignatureVerifyingErrorCounter.labels(anyString())).thenReturn(childCounter);
+        doNothing().when(childCounter).inc();
+        
+        assertThat(trustEngine.doValidate(outgoing_assertion.getSignature(), trustBasisCriteria)).isTrue();
+        verify(outgoingSignatureVerifyingErrorCounter).labels("verification_failed");
+        verify(childCounter).inc();
+    }
+
+    private static void setFinalStatic(Field field, Object newValue) throws Exception {
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newValue);
+    }
+}


### PR DESCRIPTION
As a developer I want to know that the Hub is validating SAML responses using the "outgoing" SAML signing certificate, so that I know it is not safe to remove this certificate from metadata.

As part of the IDP SAML Certificate process, a new signing certificate is introduced to metadata for that IDP.

The "outgoing" cert is set to the "backup" position, and the Hub will validate SAML responses using the new cert, then the outgoing cert.

When there are two certs used for validation, and we successfully use the outgoing cert to validate, we can be sure that the IDP has not yet started using their new signing key. In this condition, set a Prometheus counter.