### PR TITLE
BAU: Use the outgoing signing verifying counter

### DIFF
--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/CredentialFactorySignatureValidator.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/CredentialFactorySignatureValidator.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.saml.security;
 
-
+import io.prometheus.client.Counter;
 import net.shibboleth.utilities.java.support.resolver.Criterion;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialResolver;
@@ -9,7 +9,6 @@ import org.opensaml.security.trust.TrustEngine;
 import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.Signature;
-import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.saml.security.signature.OutgoingKeySignatureTrustEngine;
 
 import javax.xml.namespace.QName;
@@ -18,7 +17,11 @@ import java.util.List;
 
 public class CredentialFactorySignatureValidator extends SignatureValidator {
     private final SigningCredentialFactory credentialFactory;
-
+    private static final Counter counter = Counter.build(
+            "verify_saml_lib_signature_verifying_error_counter",
+            "Counter to detect errors on the outgoing signature, reports the number of errors")
+            .labelNames("error_type")
+            .register();
 
     public CredentialFactorySignatureValidator(SigningCredentialFactory credentialFactory) {
         this.credentialFactory = credentialFactory;
@@ -35,6 +38,6 @@ public class CredentialFactorySignatureValidator extends SignatureValidator {
 
         CredentialResolver credResolver = new StaticCredentialResolver(credentials);
         KeyInfoCredentialResolver kiResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
-        return new OutgoingKeySignatureTrustEngine(credResolver, kiResolver);
+        return new OutgoingKeySignatureTrustEngine(credResolver, kiResolver, counter);
     }
 }

--- a/saml-lib/src/main/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngine.java
+++ b/saml-lib/src/main/java/uk/gov/ida/saml/security/signature/OutgoingKeySignatureTrustEngine.java
@@ -29,15 +29,15 @@ public class OutgoingKeySignatureTrustEngine extends ExplicitKeySignatureTrustEn
      *                        trusted credential store
      */
     private final Logger log = LoggerFactory.getLogger(OutgoingKeySignatureTrustEngine.class);
+    private final Counter outgoingSignatureVerifyingErrorCounter;
 
-    private static final Counter outgoingSignatureVerifyingErrorCounter = Counter.build(
-                    "verify_saml_lib_signature_verifying_error_counter",
-                    "Counter to detect errors on the outgoing signature, reports the number of errors")
-            .labelNames("error_type")
-            .register();
-
-    public OutgoingKeySignatureTrustEngine(@Nonnull CredentialResolver resolver, @Nonnull KeyInfoCredentialResolver keyInfoResolver) {
+    public OutgoingKeySignatureTrustEngine(
+            @Nonnull CredentialResolver resolver,
+            @Nonnull KeyInfoCredentialResolver keyInfoResolver,
+            @Nonnull Counter outgoingSignatureVerifyingErrorCounter
+    ) {
         super(resolver, keyInfoResolver);
+        this.outgoingSignatureVerifyingErrorCounter = outgoingSignatureVerifyingErrorCounter;
     }
 
     @Override


### PR DESCRIPTION
The ExplicitKeySignatureTrustEngine(credResolver, kiResolver) is replaced with the counter version OutgoingKeySignatureTrustEngine

Test are now passing, by using in memory public key for the test and adjusting injecting the counter at the point of creation